### PR TITLE
Fixed most compiler warnings -Wall -Wextra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ compiler:
 - clang
 - gcc
 
-script: ./bootstrap && ./configure && make && make test
+script: ./bootstrap && ./configure && make && make check

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 # Define the package version numbers and the bug reporting link.
 m4_define([YAML_MAJOR], 0)
 m4_define([YAML_MINOR], 1)
-m4_define([YAML_PATCH], 6)
+m4_define([YAML_PATCH], 7)
 m4_define([YAML_BUGS], [http://pyyaml.org/newticket?component=libyaml])
 
 # Define the libtool version numbers; check the Autobook, Section 11.4.
@@ -18,9 +18,9 @@ m4_define([YAML_BUGS], [http://pyyaml.org/newticket?component=libyaml])
 #       else:
 #           YAML_AGE = 0
 m4_define([YAML_RELEASE], 0)
-m4_define([YAML_CURRENT], 2)
+m4_define([YAML_CURRENT], 3)
 m4_define([YAML_REVISION], 4)
-m4_define([YAML_AGE], 0)
+m4_define([YAML_AGE], 1)
 
 # Initialize autoconf & automake.
 AC_PREREQ(2.59)

--- a/include/yaml.h
+++ b/include/yaml.h
@@ -1519,6 +1519,18 @@ typedef enum yaml_emitter_state_e {
     YAML_EMIT_END_STATE
 } yaml_emitter_state_t;
 
+
+/* This is needed for C++ */
+
+typedef struct yaml_anchors_s {
+    /** The number of references. */
+    int references;
+    /** The anchor id. */
+    int anchor;
+    /** If the node has been emitted? */
+    int serialized;
+} yaml_anchors_t;
+
 /**
  * The emitter structure.
  *
@@ -1746,14 +1758,7 @@ typedef struct yaml_emitter_s {
     int closed;
 
     /** The information associated with the document nodes. */
-    struct {
-        /** The number of references. */
-        int references;
-        /** The anchor id. */
-        int anchor;
-        /** If the node has been emitted? */
-        int serialized;
-    } *anchors;
+    yaml_anchors_t *anchors;
 
     /** The last assigned anchor id. */
     int last_anchor_id;

--- a/include/yaml.h
+++ b/include/yaml.h
@@ -1296,6 +1296,10 @@ typedef struct yaml_parser_s {
     /** The currently parsed document. */
     yaml_document_t *document;
 
+    /** Optionally forgive some reader errors.
+     * Make them non-fatal. */
+    int problem_nonstrict;
+
     /**
      * @}
      */
@@ -1682,6 +1686,8 @@ typedef struct yaml_emitter_s {
     int indention;
     /** If an explicit document end is required? */
     int open_ended;
+    /** If a map requires a new indent (backcompat, unreadable by YAML.pm) */
+    int indentless_map;
 
     /** Anchor analysis. */
     struct {

--- a/src/api.c
+++ b/src/api.c
@@ -74,7 +74,7 @@ YAML_DECLARE(int)
 yaml_string_extend(yaml_char_t **start,
         yaml_char_t **pointer, yaml_char_t **end)
 {
-    yaml_char_t *new_start = yaml_realloc(*start, (*end - *start)*2);
+    yaml_char_t *new_start = (yaml_char_t *)yaml_realloc((void*)*start, (*end - *start)*2);
 
     if (!new_start) return 0;
 
@@ -94,8 +94,9 @@ yaml_string_extend(yaml_char_t **start,
 YAML_DECLARE(int)
 yaml_string_join(
         yaml_char_t **a_start, yaml_char_t **a_pointer, yaml_char_t **a_end,
-        yaml_char_t **b_start, yaml_char_t **b_pointer, yaml_char_t **b_end)
+        yaml_char_t **b_start, yaml_char_t **b_pointer, SHIM(yaml_char_t **b_end))
 {
+    UNUSED_PARAM(b_end)
     if (*b_start == *b_pointer)
         return 1;
 
@@ -177,17 +178,17 @@ yaml_parser_initialize(yaml_parser_t *parser)
         goto error;
     if (!BUFFER_INIT(parser, parser->buffer, INPUT_BUFFER_SIZE))
         goto error;
-    if (!QUEUE_INIT(parser, parser->tokens, INITIAL_QUEUE_SIZE))
+    if (!QUEUE_INIT(parser, parser->tokens, INITIAL_QUEUE_SIZE, yaml_token_t*))
         goto error;
-    if (!STACK_INIT(parser, parser->indents, INITIAL_STACK_SIZE))
+    if (!STACK_INIT(parser, parser->indents, int*))
         goto error;
-    if (!STACK_INIT(parser, parser->simple_keys, INITIAL_STACK_SIZE))
+    if (!STACK_INIT(parser, parser->simple_keys, yaml_simple_key_t*))
         goto error;
-    if (!STACK_INIT(parser, parser->states, INITIAL_STACK_SIZE))
+    if (!STACK_INIT(parser, parser->states, yaml_parser_state_t*))
         goto error;
-    if (!STACK_INIT(parser, parser->marks, INITIAL_STACK_SIZE))
+    if (!STACK_INIT(parser, parser->marks, yaml_mark_t*))
         goto error;
-    if (!STACK_INIT(parser, parser->tag_directives, INITIAL_STACK_SIZE))
+    if (!STACK_INIT(parser, parser->tag_directives, yaml_tag_directive_t*))
         goto error;
 
     return 1;
@@ -243,7 +244,7 @@ static int
 yaml_string_read_handler(void *data, unsigned char *buffer, size_t size,
         size_t *size_read)
 {
-    yaml_parser_t *parser = data;
+    yaml_parser_t *parser = (yaml_parser_t *)data;
 
     if (parser->input.string.current == parser->input.string.end) {
         *size_read = 0;
@@ -269,7 +270,7 @@ static int
 yaml_file_read_handler(void *data, unsigned char *buffer, size_t size,
         size_t *size_read)
 {
-    yaml_parser_t *parser = data;
+    yaml_parser_t *parser = (yaml_parser_t *)data;
 
     *size_read = fread(buffer, 1, size, parser->input.file);
     return !ferror(parser->input.file);
@@ -355,13 +356,13 @@ yaml_emitter_initialize(yaml_emitter_t *emitter)
         goto error;
     if (!BUFFER_INIT(emitter, emitter->raw_buffer, OUTPUT_RAW_BUFFER_SIZE))
         goto error;
-    if (!STACK_INIT(emitter, emitter->states, INITIAL_STACK_SIZE))
+    if (!STACK_INIT(emitter, emitter->states, yaml_emitter_state_t*))
         goto error;
-    if (!QUEUE_INIT(emitter, emitter->events, INITIAL_QUEUE_SIZE))
+    if (!QUEUE_INIT(emitter, emitter->events, INITIAL_QUEUE_SIZE, yaml_event_t*))
         goto error;
-    if (!STACK_INIT(emitter, emitter->indents, INITIAL_STACK_SIZE))
+    if (!STACK_INIT(emitter, emitter->indents, int*))
         goto error;
-    if (!STACK_INIT(emitter, emitter->tag_directives, INITIAL_STACK_SIZE))
+    if (!STACK_INIT(emitter, emitter->tag_directives, yaml_tag_directive_t*))
         goto error;
 
     return 1;
@@ -413,7 +414,7 @@ yaml_emitter_delete(yaml_emitter_t *emitter)
 static int
 yaml_string_write_handler(void *data, unsigned char *buffer, size_t size)
 {
-    yaml_emitter_t *emitter = data;
+  yaml_emitter_t *emitter = (yaml_emitter_t *)data;
 
     if (emitter->output.string.size + *emitter->output.string.size_written
             < size) {
@@ -439,7 +440,7 @@ yaml_string_write_handler(void *data, unsigned char *buffer, size_t size)
 static int
 yaml_file_write_handler(void *data, unsigned char *buffer, size_t size)
 {
-    yaml_emitter_t *emitter = data;
+    yaml_emitter_t *emitter = (yaml_emitter_t *)data;
 
     return (fwrite(buffer, 1, size, emitter->output.file) == size);
 }
@@ -717,7 +718,7 @@ yaml_document_start_event_initialize(yaml_event_t *event,
                             /* Valid tag directives are expected. */
 
     if (version_directive) {
-        version_directive_copy = yaml_malloc(sizeof(yaml_version_directive_t));
+        version_directive_copy = YAML_MALLOC_STATIC(yaml_version_directive_t);
         if (!version_directive_copy) goto error;
         version_directive_copy->major = version_directive->major;
         version_directive_copy->minor = version_directive->minor;
@@ -725,7 +726,7 @@ yaml_document_start_event_initialize(yaml_event_t *event,
 
     if (tag_directives_start != tag_directives_end) {
         yaml_tag_directive_t *tag_directive;
-        if (!STACK_INIT(&context, tag_directives_copy, INITIAL_STACK_SIZE))
+        if (!STACK_INIT(&context, tag_directives_copy, yaml_tag_directive_t*))
             goto error;
         for (tag_directive = tag_directives_start;
                 tag_directive != tag_directives_end; tag_directive ++) {
@@ -843,7 +844,7 @@ yaml_scalar_event_initialize(yaml_event_t *event,
     }
 
     if (!yaml_check_utf8(value, length)) goto error;
-    value_copy = yaml_malloc(length+1);
+    value_copy = YAML_MALLOC(length+1);
     if (!value_copy) goto error;
     memcpy(value_copy, value, length);
     value_copy[length] = '\0';
@@ -1055,10 +1056,10 @@ yaml_document_initialize(yaml_document_t *document,
             (tag_directives_start == tag_directives_end));
                             /* Valid tag directives are expected. */
 
-    if (!STACK_INIT(&context, nodes, INITIAL_STACK_SIZE)) goto error;
+    if (!STACK_INIT(&context, nodes, yaml_node_t*)) goto error;
 
     if (version_directive) {
-        version_directive_copy = yaml_malloc(sizeof(yaml_version_directive_t));
+        version_directive_copy = YAML_MALLOC_STATIC(yaml_version_directive_t);
         if (!version_directive_copy) goto error;
         version_directive_copy->major = version_directive->major;
         version_directive_copy->minor = version_directive->minor;
@@ -1066,7 +1067,7 @@ yaml_document_initialize(yaml_document_t *document,
 
     if (tag_directives_start != tag_directives_end) {
         yaml_tag_directive_t *tag_directive;
-        if (!STACK_INIT(&context, tag_directives_copy, INITIAL_STACK_SIZE))
+        if (!STACK_INIT(&context, tag_directives_copy, yaml_tag_directive_t*))
             goto error;
         for (tag_directive = tag_directives_start;
                 tag_directive != tag_directives_end; tag_directive ++) {
@@ -1219,7 +1220,7 @@ yaml_document_add_scalar(yaml_document_t *document,
     }
 
     if (!yaml_check_utf8(value, length)) goto error;
-    value_copy = yaml_malloc(length+1);
+    value_copy = YAML_MALLOC(length+1);
     if (!value_copy) goto error;
     memcpy(value_copy, value, length);
     value_copy[length] = '\0';
@@ -1266,7 +1267,7 @@ yaml_document_add_sequence(yaml_document_t *document,
     tag_copy = yaml_strdup(tag);
     if (!tag_copy) goto error;
 
-    if (!STACK_INIT(&context, items, INITIAL_STACK_SIZE)) goto error;
+    if (!STACK_INIT(&context, items, yaml_node_item_t*)) goto error;
 
     SEQUENCE_NODE_INIT(node, tag_copy, items.start, items.end,
             style, mark, mark);
@@ -1311,7 +1312,7 @@ yaml_document_add_mapping(yaml_document_t *document,
     tag_copy = yaml_strdup(tag);
     if (!tag_copy) goto error;
 
-    if (!STACK_INIT(&context, pairs, INITIAL_STACK_SIZE)) goto error;
+    if (!STACK_INIT(&context, pairs, yaml_node_pair_t*)) goto error;
 
     MAPPING_NODE_INIT(node, tag_copy, pairs.start, pairs.end,
             style, mark, mark);

--- a/src/dumper.c
+++ b/src/dumper.c
@@ -245,9 +245,9 @@ yaml_emitter_anchor_node(yaml_emitter_t *emitter, int index)
 #define ANCHOR_TEMPLATE_LENGTH  16
 
 static yaml_char_t *
-yaml_emitter_generate_anchor(yaml_emitter_t *emitter, int anchor_id)
+yaml_emitter_generate_anchor(SHIM(yaml_emitter_t *emitter), int anchor_id)
 {
-    yaml_char_t *anchor = yaml_malloc(ANCHOR_TEMPLATE_LENGTH);
+    yaml_char_t *anchor = YAML_MALLOC(ANCHOR_TEMPLATE_LENGTH);
 
     if (!anchor) return NULL;
 

--- a/src/dumper.c
+++ b/src/dumper.c
@@ -131,7 +131,7 @@ yaml_emitter_dump(yaml_emitter_t *emitter, yaml_document_t *document)
 
     assert(emitter->opened);    /* Emitter should be opened. */
 
-    emitter->anchors = yaml_malloc(sizeof(*(emitter->anchors))
+    emitter->anchors = (yaml_anchors_t*)yaml_malloc(sizeof(*(emitter->anchors))
             * (document->nodes.top - document->nodes.start));
     if (!emitter->anchors) goto error;
     memset(emitter->anchors, 0, sizeof(*(emitter->anchors))

--- a/src/emitter.c
+++ b/src/emitter.c
@@ -16,7 +16,7 @@
 #define PUT(emitter,value)                                                      \
     (FLUSH(emitter)                                                             \
      && (*(emitter->buffer.pointer++) = (yaml_char_t)(value),                   \
-         emitter->column ++,                                                    \
+         emitter->column++,                                             	\
          1))
 
 /*

--- a/src/emitter.c
+++ b/src/emitter.c
@@ -1002,7 +1002,7 @@ yaml_emitter_emit_node(yaml_emitter_t *emitter, yaml_event_t *event,
  */
 
 static int
-yaml_emitter_emit_alias(yaml_emitter_t *emitter, yaml_event_t *event)
+yaml_emitter_emit_alias(yaml_emitter_t *emitter, SHIM(yaml_event_t *event))
 {
     if (!yaml_emitter_process_anchor(emitter))
         return 0;
@@ -1087,7 +1087,7 @@ yaml_emitter_emit_mapping_start(yaml_emitter_t *emitter, yaml_event_t *event)
  */
 
 static int
-yaml_emitter_check_empty_document(yaml_emitter_t *emitter)
+yaml_emitter_check_empty_document(SHIM(yaml_emitter_t *emitter))
 {
     return 0;
 }

--- a/src/emitter.c
+++ b/src/emitter.c
@@ -993,8 +993,6 @@ yaml_emitter_emit_node(yaml_emitter_t *emitter, yaml_event_t *event,
             return yaml_emitter_set_emitter_error(emitter,
                     "expected SCALAR, SEQUENCE-START, MAPPING-START, or ALIAS");
     }
-
-    return 0;
 }
 
 /*
@@ -1753,7 +1751,8 @@ yaml_emitter_analyze_event(yaml_emitter_t *emitter,
 static int
 yaml_emitter_write_bom(yaml_emitter_t *emitter)
 {
-    if (!FLUSH(emitter)) return 0;
+    if (!FLUSH(emitter))
+        return 0;
 
     *(emitter->buffer.pointer++) = (yaml_char_t) '\xEF';
     *(emitter->buffer.pointer++) = (yaml_char_t) '\xBB';
@@ -1769,11 +1768,13 @@ yaml_emitter_write_indent(yaml_emitter_t *emitter)
 
     if (!emitter->indention || emitter->column > indent
             || (emitter->column == indent && !emitter->whitespace)) {
-        if (!PUT_BREAK(emitter)) return 0;
+        if (!PUT_BREAK(emitter))
+            return 0;
     }
 
     while (emitter->column < indent) {
-        if (!PUT(emitter, ' ')) return 0;
+        if (!PUT(emitter, ' '))
+            return 0;
     }
 
     emitter->whitespace = 1;
@@ -1794,11 +1795,13 @@ yaml_emitter_write_indicator(yaml_emitter_t *emitter,
     STRING_ASSIGN(string, (yaml_char_t *)indicator, indicator_length);
 
     if (need_whitespace && !emitter->whitespace) {
-        if (!PUT(emitter, ' ')) return 0;
+        if (!PUT(emitter, ' '))
+            return 0;
     }
 
     while (string.pointer != string.end) {
-        if (!WRITE(emitter, string)) return 0;
+        if (!WRITE(emitter, string))
+            return 0;
     }
 
     emitter->whitespace = is_whitespace;
@@ -1816,7 +1819,8 @@ yaml_emitter_write_anchor(yaml_emitter_t *emitter,
     STRING_ASSIGN(string, value, length);
 
     while (string.pointer != string.end) {
-        if (!WRITE(emitter, string)) return 0;
+        if (!WRITE(emitter, string))
+            return 0;
     }
 
     emitter->whitespace = 0;
@@ -1833,11 +1837,13 @@ yaml_emitter_write_tag_handle(yaml_emitter_t *emitter,
     STRING_ASSIGN(string, value, length);
 
     if (!emitter->whitespace) {
-        if (!PUT(emitter, ' ')) return 0;
+        if (!PUT(emitter, ' '))
+            return 0;
     }
 
     while (string.pointer != string.end) {
-        if (!WRITE(emitter, string)) return 0;
+        if (!WRITE(emitter, string))
+            return 0;
     }
 
     emitter->whitespace = 0;
@@ -1855,7 +1861,8 @@ yaml_emitter_write_tag_content(yaml_emitter_t *emitter,
     STRING_ASSIGN(string, value, length);
 
     if (need_whitespace && !emitter->whitespace) {
-        if (!PUT(emitter, ' ')) return 0;
+        if (!PUT(emitter, ' '))
+            return 0;
     }
 
     while (string.pointer != string.end) {
@@ -1870,19 +1877,21 @@ yaml_emitter_write_tag_content(yaml_emitter_t *emitter,
                 || CHECK(string, '\'') || CHECK(string, '(')
                 || CHECK(string, ')') || CHECK(string, '[')
                 || CHECK(string, ']')) {
-            if (!WRITE(emitter, string)) return 0;
+            if (!WRITE(emitter, string))
+                return 0;
         }
         else {
             int width = WIDTH(string);
-            unsigned int value;
+            unsigned int v;
             while (width --) {
-                value = *(string.pointer++);
-                if (!PUT(emitter, '%')) return 0;
-                if (!PUT(emitter, (value >> 4)
-                            + ((value >> 4) < 10 ? '0' : 'A' - 10)))
+                v = *(string.pointer++);
+                if (!PUT(emitter, '%'))
                     return 0;
-                if (!PUT(emitter, (value & 0x0F)
-                            + ((value & 0x0F) < 10 ? '0' : 'A' - 10)))
+                if (!PUT(emitter, (v >> 4)
+                               + ((v >> 4) < 10 ? '0' : 'A' - 10)))
+                    return 0;
+                if (!PUT(emitter, (v & 0x0F)
+                               + ((v & 0x0F) < 10 ? '0' : 'A' - 10)))
                     return 0;
             }
         }
@@ -1905,39 +1914,43 @@ yaml_emitter_write_plain_scalar(yaml_emitter_t *emitter,
     STRING_ASSIGN(string, value, length);
 
     if (!emitter->whitespace) {
-        if (!PUT(emitter, ' ')) return 0;
+        if (!PUT(emitter, ' '))
+            return 0;
     }
 
     while (string.pointer != string.end)
     {
-        if (IS_SPACE(string))
-        {
+        if (IS_SPACE(string)) {
             if (allow_breaks && !spaces
                     && emitter->column > emitter->best_width
                     && !IS_SPACE_AT(string, 1)) {
-                if (!yaml_emitter_write_indent(emitter)) return 0;
+                if (!yaml_emitter_write_indent(emitter))
+                    return 0;
                 MOVE(string);
             }
             else {
-                if (!WRITE(emitter, string)) return 0;
+                if (!WRITE(emitter, string))
+                    return 0;
             }
             spaces = 1;
         }
-        else if (IS_BREAK(string))
-        {
+        else if (IS_BREAK(string)) {
             if (!breaks && CHECK(string, '\n')) {
-                if (!PUT_BREAK(emitter)) return 0;
+                if (!PUT_BREAK(emitter))
+                    return 0;
             }
-            if (!WRITE_BREAK(emitter, string)) return 0;
+            if (!WRITE_BREAK(emitter, string))
+                return 0;
             emitter->indention = 1;
             breaks = 1;
         }
-        else
-        {
+        else {
             if (breaks) {
-                if (!yaml_emitter_write_indent(emitter)) return 0;
+                if (!yaml_emitter_write_indent(emitter))
+                    return 0;
             }
-            if (!WRITE(emitter, string)) return 0;
+            if (!WRITE(emitter, string))
+                return 0;
             emitter->indention = 0;
             spaces = 0;
             breaks = 0;
@@ -1974,39 +1987,44 @@ yaml_emitter_write_single_quoted_scalar(yaml_emitter_t *emitter,
 
     while (string.pointer != string.end)
     {
-        if (IS_SPACE(string))
-        {
+        if (IS_SPACE(string)) {
             if (allow_breaks && !spaces
                     && emitter->column > emitter->best_width
                     && string.pointer != string.start
                     && string.pointer != string.end - 1
                     && !IS_SPACE_AT(string, 1)) {
-                if (!yaml_emitter_write_indent(emitter)) return 0;
+                if (!yaml_emitter_write_indent(emitter))
+                    return 0;
                 MOVE(string);
             }
             else {
-                if (!WRITE(emitter, string)) return 0;
+                if (!WRITE(emitter, string))
+                    return 0;
             }
             spaces = 1;
         }
-        else if (IS_BREAK(string))
-        {
+        else if (IS_BREAK(string)) {
             if (!breaks && CHECK(string, '\n')) {
-                if (!PUT_BREAK(emitter)) return 0;
+                if (!PUT_BREAK(emitter))
+                    return 0;
             }
-            if (!WRITE_BREAK(emitter, string)) return 0;
+            if (!WRITE_BREAK(emitter, string))
+                return 0;
             emitter->indention = 1;
             breaks = 1;
         }
         else
         {
             if (breaks) {
-                if (!yaml_emitter_write_indent(emitter)) return 0;
+                if (!yaml_emitter_write_indent(emitter))
+                    return 0;
             }
             if (CHECK(string, '\'')) {
-                if (!PUT(emitter, '\'')) return 0;
+                if (!PUT(emitter, '\''))
+                    return 0;
             }
-            if (!WRITE(emitter, string)) return 0;
+            if (!WRITE(emitter, string))
+                return 0;
             emitter->indention = 0;
             spaces = 0;
             breaks = 0;
@@ -2042,7 +2060,7 @@ yaml_emitter_write_double_quoted_scalar(yaml_emitter_t *emitter,
         {
             unsigned char octet;
             unsigned int width;
-            unsigned int value;
+            unsigned int v;
             int k;
 
             octet = string.pointer[0];
@@ -2050,121 +2068,142 @@ yaml_emitter_write_double_quoted_scalar(yaml_emitter_t *emitter,
                     (octet & 0xE0) == 0xC0 ? 2 :
                     (octet & 0xF0) == 0xE0 ? 3 :
                     (octet & 0xF8) == 0xF0 ? 4 : 0;
-            value = (octet & 0x80) == 0x00 ? octet & 0x7F :
+            v     = (octet & 0x80) == 0x00 ? octet & 0x7F :
                     (octet & 0xE0) == 0xC0 ? octet & 0x1F :
                     (octet & 0xF0) == 0xE0 ? octet & 0x0F :
                     (octet & 0xF8) == 0xF0 ? octet & 0x07 : 0;
             for (k = 1; k < (int)width; k ++) {
                 octet = string.pointer[k];
-                value = (value << 6) + (octet & 0x3F);
+                v     = (v << 6) + (octet & 0x3F);
             }
             string.pointer += width;
 
-            if (!PUT(emitter, '\\')) return 0;
+            if (!PUT(emitter, '\\'))
+                return 0;
 
-            switch (value)
+            switch (v)
             {
                 case 0x00:
-                    if (!PUT(emitter, '0')) return 0;
+                    if (!PUT(emitter, '0'))
+                        return 0;
                     break;
 
                 case 0x07:
-                    if (!PUT(emitter, 'a')) return 0;
+                    if (!PUT(emitter, 'a'))
+                        return 0;
                     break;
 
                 case 0x08:
-                    if (!PUT(emitter, 'b')) return 0;
+                    if (!PUT(emitter, 'b'))
+                        return 0;
                     break;
 
                 case 0x09:
-                    if (!PUT(emitter, 't')) return 0;
+                    if (!PUT(emitter, 't'))
+                        return 0;
                     break;
 
                 case 0x0A:
-                    if (!PUT(emitter, 'n')) return 0;
+                    if (!PUT(emitter, 'n'))
+                        return 0;
                     break;
 
                 case 0x0B:
-                    if (!PUT(emitter, 'v')) return 0;
+                    if (!PUT(emitter, 'v'))
+                        return 0;
                     break;
 
                 case 0x0C:
-                    if (!PUT(emitter, 'f')) return 0;
+                    if (!PUT(emitter, 'f'))
+                        return 0;
                     break;
 
                 case 0x0D:
-                    if (!PUT(emitter, 'r')) return 0;
+                    if (!PUT(emitter, 'r'))
+                        return 0;
                     break;
 
                 case 0x1B:
-                    if (!PUT(emitter, 'e')) return 0;
+                    if (!PUT(emitter, 'e'))
+                        return 0;
                     break;
 
                 case 0x22:
-                    if (!PUT(emitter, '\"')) return 0;
+                    if (!PUT(emitter, '\"'))
+                        return 0;
                     break;
 
                 case 0x5C:
-                    if (!PUT(emitter, '\\')) return 0;
+                    if (!PUT(emitter, '\\'))
+                        return 0;
                     break;
 
                 case 0x85:
-                    if (!PUT(emitter, 'N')) return 0;
+                    if (!PUT(emitter, 'N'))
+                        return 0;
                     break;
 
                 case 0xA0:
-                    if (!PUT(emitter, '_')) return 0;
+                    if (!PUT(emitter, '_'))
+                        return 0;
                     break;
 
                 case 0x2028:
-                    if (!PUT(emitter, 'L')) return 0;
+                    if (!PUT(emitter, 'L'))
+                        return 0;
                     break;
 
                 case 0x2029:
-                    if (!PUT(emitter, 'P')) return 0;
+                    if (!PUT(emitter, 'P'))
+                        return 0;
                     break;
 
                 default:
-                    if (value <= 0xFF) {
-                        if (!PUT(emitter, 'x')) return 0;
+                    if (v <= 0xFF) {
+                        if (!PUT(emitter, 'x'))
+                            return 0;
                         width = 2;
                     }
-                    else if (value <= 0xFFFF) {
-                        if (!PUT(emitter, 'u')) return 0;
+                    else if (v <= 0xFFFF) {
+                        if (!PUT(emitter, 'u'))
+                            return 0;
                         width = 4;
                     }
                     else {
-                        if (!PUT(emitter, 'U')) return 0;
+                        if (!PUT(emitter, 'U'))
+                            return 0;
                         width = 8;
                     }
                     for (k = (width-1)*4; k >= 0; k -= 4) {
-                        int digit = (value >> k) & 0x0F;
+                        int digit = (v >> k) & 0x0F;
                         if (!PUT(emitter, digit + (digit < 10 ? '0' : 'A'-10)))
                             return 0;
                     }
             }
             spaces = 0;
         }
-        else if (IS_SPACE(string))
-        {
+        else if (IS_SPACE(string)) {
             if (allow_breaks && !spaces
                     && emitter->column > emitter->best_width
                     && string.pointer != string.start
                     && string.pointer != string.end - 1) {
-                if (!yaml_emitter_write_indent(emitter)) return 0;
+                if (!yaml_emitter_write_indent(emitter))
+                    return 0;
                 if (IS_SPACE_AT(string, 1)) {
-                    if (!PUT(emitter, '\\')) return 0;
+                    if (!PUT(emitter, '\\'))
+                        return 0;
                 }
                 MOVE(string);
             }
             else {
-                if (!WRITE(emitter, string)) return 0;
+                if (!WRITE(emitter, string))
+                    return 0;
             }
             spaces = 1;
         }
-        else
-        {
-            if (!WRITE(emitter, string)) return 0;
+        else {
+            if (!WRITE(emitter, string))
+                return 0;
             spaces = 0;
         }
     }
@@ -2185,8 +2224,7 @@ yaml_emitter_write_block_scalar_hints(yaml_emitter_t *emitter,
     char indent_hint[2];
     char *chomp_hint = NULL;
 
-    if (IS_SPACE(string) || IS_BREAK(string))
-    {
+    if (IS_SPACE(string) || IS_BREAK(string)) {
         indent_hint[0] = '0' + (char)emitter->best_indent;
         indent_hint[1] = '\0';
         if (!yaml_emitter_write_indicator(emitter, indent_hint, 0, 0, 0))
@@ -2196,39 +2234,32 @@ yaml_emitter_write_block_scalar_hints(yaml_emitter_t *emitter,
     emitter->open_ended = 0;
 
     string.pointer = string.end;
-    if (string.start == string.pointer)
-    {
+    if (string.start == string.pointer) {
         chomp_hint = "-";
     }
-    else
-    {
+    else {
         do {
             string.pointer --;
         } while ((*string.pointer & 0xC0) == 0x80);
-        if (!IS_BREAK(string))
-        {
+        if (!IS_BREAK(string)) {
             chomp_hint = "-";
         }
-        else if (string.start == string.pointer)
-        {
+        else if (string.start == string.pointer) {
             chomp_hint = "+";
             emitter->open_ended = 1;
         }
-        else
-        {
+        else {
             do {
                 string.pointer --;
             } while ((*string.pointer & 0xC0) == 0x80);
-            if (IS_BREAK(string))
-            {
+            if (IS_BREAK(string)) {
                 chomp_hint = "+";
                 emitter->open_ended = 1;
             }
         }
     }
 
-    if (chomp_hint)
-    {
+    if (chomp_hint) {
         if (!yaml_emitter_write_indicator(emitter, chomp_hint, 0, 0, 0))
             return 0;
     }
@@ -2249,7 +2280,8 @@ yaml_emitter_write_literal_scalar(yaml_emitter_t *emitter,
         return 0;
     if (!yaml_emitter_write_block_scalar_hints(emitter, string))
         return 0;
-    if (!PUT_BREAK(emitter)) return 0;
+    if (!PUT_BREAK(emitter))
+        return 0;
     emitter->indention = 1;
     emitter->whitespace = 1;
 
@@ -2257,16 +2289,19 @@ yaml_emitter_write_literal_scalar(yaml_emitter_t *emitter,
     {
         if (IS_BREAK(string))
         {
-            if (!WRITE_BREAK(emitter, string)) return 0;
+            if (!WRITE_BREAK(emitter, string))
+                return 0;
             emitter->indention = 1;
             breaks = 1;
         }
         else
         {
             if (breaks) {
-                if (!yaml_emitter_write_indent(emitter)) return 0;
+                if (!yaml_emitter_write_indent(emitter))
+                    return 0;
             }
-            if (!WRITE(emitter, string)) return 0;
+            if (!WRITE(emitter, string))
+                        return 0;
             emitter->indention = 0;
             breaks = 0;
         }
@@ -2289,7 +2324,8 @@ yaml_emitter_write_folded_scalar(yaml_emitter_t *emitter,
         return 0;
     if (!yaml_emitter_write_block_scalar_hints(emitter, string))
         return 0;
-    if (!PUT_BREAK(emitter)) return 0;
+    if (!PUT_BREAK(emitter))
+        return 0;
     emitter->indention = 1;
     emitter->whitespace = 1;
 
@@ -2303,26 +2339,31 @@ yaml_emitter_write_folded_scalar(yaml_emitter_t *emitter,
                     k += WIDTH_AT(string, k);
                 }
                 if (!IS_BLANKZ_AT(string, k)) {
-                    if (!PUT_BREAK(emitter)) return 0;
+                    if (!PUT_BREAK(emitter))
+                        return 0;
                 }
             }
-            if (!WRITE_BREAK(emitter, string)) return 0;
+            if (!WRITE_BREAK(emitter, string))
+                return 0;
             emitter->indention = 1;
             breaks = 1;
         }
         else
         {
             if (breaks) {
-                if (!yaml_emitter_write_indent(emitter)) return 0;
+                if (!yaml_emitter_write_indent(emitter))
+                    return 0;
                 leading_spaces = IS_BLANK(string);
             }
             if (!breaks && IS_SPACE(string) && !IS_SPACE_AT(string, 1)
                     && emitter->column > emitter->best_width) {
-                if (!yaml_emitter_write_indent(emitter)) return 0;
+                if (!yaml_emitter_write_indent(emitter))
+                    return 0;
                 MOVE(string);
             }
             else {
-                if (!WRITE(emitter, string)) return 0;
+                if (!WRITE(emitter, string))
+                    return 0;
             }
             emitter->indention = 0;
             breaks = 0;

--- a/src/emitter.c
+++ b/src/emitter.c
@@ -869,7 +869,7 @@ yaml_emitter_emit_block_sequence_item(yaml_emitter_t *emitter,
     if (first)
     {
         if (!yaml_emitter_increase_indent(emitter, 0,
-                    (emitter->mapping_context && !emitter->indention)))
+            emitter->indentless_map && (emitter->mapping_context && !emitter->indention)))
             return 0;
     }
 

--- a/src/loader.c
+++ b/src/loader.c
@@ -72,7 +72,7 @@ yaml_parser_load(yaml_parser_t *parser, yaml_document_t *document)
     assert(document);   /* Non-NULL document object is expected. */
 
     memset(document, 0, sizeof(yaml_document_t));
-    if (!STACK_INIT(parser, document->nodes, INITIAL_STACK_SIZE))
+    if (!STACK_INIT(parser, document->nodes, yaml_node_t*))
         goto error;
 
     if (!parser->stream_start_produced) {
@@ -90,7 +90,7 @@ yaml_parser_load(yaml_parser_t *parser, yaml_document_t *document)
         return 1;
     }
 
-    if (!STACK_INIT(parser, parser->aliases, INITIAL_STACK_SIZE))
+    if (!STACK_INIT(parser, parser->aliases, yaml_alias_data_t*))
         goto error;
 
     parser->document = document;
@@ -339,7 +339,7 @@ yaml_parser_load_sequence(yaml_parser_t *parser, yaml_event_t *first_event)
         if (!tag) goto error;
     }
 
-    if (!STACK_INIT(parser, items, INITIAL_STACK_SIZE)) goto error;
+    if (!STACK_INIT(parser, items, yaml_node_item_t*)) goto error;
 
     SEQUENCE_NODE_INIT(node, tag, items.start, items.end,
             first_event->data.sequence_start.style,
@@ -402,7 +402,7 @@ yaml_parser_load_mapping(yaml_parser_t *parser, yaml_event_t *first_event)
         if (!tag) goto error;
     }
 
-    if (!STACK_INIT(parser, pairs, INITIAL_STACK_SIZE)) goto error;
+    if (!STACK_INIT(parser, pairs, yaml_node_pair_t*)) goto error;
 
     MAPPING_NODE_INIT(node, tag, pairs.start, pairs.end,
             first_event->data.mapping_start.style,

--- a/src/loader.c
+++ b/src/loader.c
@@ -76,16 +76,18 @@ yaml_parser_load(yaml_parser_t *parser, yaml_document_t *document)
         goto error;
 
     if (!parser->stream_start_produced) {
-        if (!yaml_parser_parse(parser, &event)) goto error;
+        if (!yaml_parser_parse(parser, &event))
+            goto error;
         assert(event.type == YAML_STREAM_START_EVENT);
-                        /* STREAM-START is expected. */
+        /* STREAM-START is expected. */
     }
 
     if (parser->stream_end_produced) {
         return 1;
     }
 
-    if (!yaml_parser_parse(parser, &event)) goto error;
+    if (!yaml_parser_parse(parser, &event))
+        goto error;
     if (event.type == YAML_STREAM_END_EVENT) {
         return 1;
     }
@@ -95,7 +97,8 @@ yaml_parser_load(yaml_parser_t *parser, yaml_document_t *document)
 
     parser->document = document;
 
-    if (!yaml_parser_load_document(parser, &event)) goto error;
+    if (!yaml_parser_load_document(parser, &event))
+        goto error;
 
     yaml_parser_delete_aliases(parser);
     parser->document = NULL;
@@ -286,24 +289,28 @@ yaml_parser_load_scalar(yaml_parser_t *parser, yaml_event_t *first_event)
     int index;
     yaml_char_t *tag = first_event->data.scalar.tag;
 
-    if (!STACK_LIMIT(parser, parser->document->nodes, INT_MAX-1)) goto error;
+    if (!STACK_LIMIT(parser, parser->document->nodes, INT_MAX-1))
+        goto error;
 
     if (!tag || strcmp((char *)tag, "!") == 0) {
         yaml_free(tag);
         tag = yaml_strdup((yaml_char_t *)YAML_DEFAULT_SCALAR_TAG);
-        if (!tag) goto error;
+        if (!tag)
+            goto error;
     }
 
     SCALAR_NODE_INIT(node, tag, first_event->data.scalar.value,
             first_event->data.scalar.length, first_event->data.scalar.style,
             first_event->start_mark, first_event->end_mark);
 
-    if (!PUSH(parser, parser->document->nodes, node)) goto error;
+    if (!PUSH(parser, parser->document->nodes, node))
+        goto error;
 
     index = parser->document->nodes.top - parser->document->nodes.start;
 
     if (!yaml_parser_register_anchor(parser, index,
-                first_event->data.scalar.anchor)) return 0;
+                first_event->data.scalar.anchor))
+        return 0;
 
     return index;
 
@@ -331,26 +338,31 @@ yaml_parser_load_sequence(yaml_parser_t *parser, yaml_event_t *first_event)
     int index, item_index;
     yaml_char_t *tag = first_event->data.sequence_start.tag;
 
-    if (!STACK_LIMIT(parser, parser->document->nodes, INT_MAX-1)) goto error;
+    if (!STACK_LIMIT(parser, parser->document->nodes, INT_MAX-1))
+        goto error;
 
     if (!tag || strcmp((char *)tag, "!") == 0) {
         yaml_free(tag);
         tag = yaml_strdup((yaml_char_t *)YAML_DEFAULT_SEQUENCE_TAG);
-        if (!tag) goto error;
+        if (!tag)
+            goto error;
     }
 
-    if (!STACK_INIT(parser, items, yaml_node_item_t*)) goto error;
+    if (!STACK_INIT(parser, items, yaml_node_item_t*))
+        goto error;
 
     SEQUENCE_NODE_INIT(node, tag, items.start, items.end,
             first_event->data.sequence_start.style,
             first_event->start_mark, first_event->end_mark);
 
-    if (!PUSH(parser, parser->document->nodes, node)) goto error;
+    if (!PUSH(parser, parser->document->nodes, node))
+        goto error;
 
     index = parser->document->nodes.top - parser->document->nodes.start;
 
     if (!yaml_parser_register_anchor(parser, index,
-                first_event->data.sequence_start.anchor)) return 0;
+                first_event->data.sequence_start.anchor))
+        return 0;
 
     if (!yaml_parser_parse(parser, &event)) return 0;
 
@@ -394,42 +406,52 @@ yaml_parser_load_mapping(yaml_parser_t *parser, yaml_event_t *first_event)
     yaml_node_pair_t pair;
     yaml_char_t *tag = first_event->data.mapping_start.tag;
 
-    if (!STACK_LIMIT(parser, parser->document->nodes, INT_MAX-1)) goto error;
+    if (!STACK_LIMIT(parser, parser->document->nodes, INT_MAX-1))
+        goto error;
 
     if (!tag || strcmp((char *)tag, "!") == 0) {
         yaml_free(tag);
         tag = yaml_strdup((yaml_char_t *)YAML_DEFAULT_MAPPING_TAG);
-        if (!tag) goto error;
+        if (!tag)
+            goto error;
     }
 
-    if (!STACK_INIT(parser, pairs, yaml_node_pair_t*)) goto error;
+    if (!STACK_INIT(parser, pairs, yaml_node_pair_t*))
+        goto error;
 
     MAPPING_NODE_INIT(node, tag, pairs.start, pairs.end,
             first_event->data.mapping_start.style,
             first_event->start_mark, first_event->end_mark);
 
-    if (!PUSH(parser, parser->document->nodes, node)) goto error;
+    if (!PUSH(parser, parser->document->nodes, node))
+        goto error;
 
     index = parser->document->nodes.top - parser->document->nodes.start;
 
     if (!yaml_parser_register_anchor(parser, index,
-                first_event->data.mapping_start.anchor)) return 0;
+                first_event->data.mapping_start.anchor))
+        return 0;
 
-    if (!yaml_parser_parse(parser, &event)) return 0;
+    if (!yaml_parser_parse(parser, &event))
+        return 0;
 
     while (event.type != YAML_MAPPING_END_EVENT) {
         if (!STACK_LIMIT(parser,
                     parser->document->nodes.start[index-1].data.mapping.pairs,
-                    INT_MAX-1)) return 0;
+                    INT_MAX-1))
+            return 0;
         pair.key = yaml_parser_load_node(parser, &event);
         if (!pair.key) return 0;
-        if (!yaml_parser_parse(parser, &event)) return 0;
+        if (!yaml_parser_parse(parser, &event))
+            return 0;
         pair.value = yaml_parser_load_node(parser, &event);
-        if (!pair.value) return 0;
+        if (!pair.value)
+            return 0;
         if (!PUSH(parser,
                     parser->document->nodes.start[index-1].data.mapping.pairs,
                     pair)) return 0;
-        if (!yaml_parser_parse(parser, &event)) return 0;
+        if (!yaml_parser_parse(parser, &event))
+            return 0;
     }
 
     parser->document->nodes.start[index-1].end_mark = event.end_mark;

--- a/src/parser.c
+++ b/src/parser.c
@@ -605,7 +605,7 @@ yaml_parser_parse_node(yaml_parser_t *parser, yaml_event_t *event,
                     if (strcmp((char *)tag_directive->handle, (char *)tag_handle) == 0) {
                         size_t prefix_len = strlen((char *)tag_directive->prefix);
                         size_t suffix_len = strlen((char *)tag_suffix);
-                        tag = yaml_malloc(prefix_len+suffix_len+1);
+                        tag = YAML_MALLOC(prefix_len+suffix_len+1);
                         if (!tag) {
                             parser->error = YAML_MEMORY_ERROR;
                             goto error;
@@ -685,7 +685,7 @@ yaml_parser_parse_node(yaml_parser_t *parser, yaml_event_t *event,
                 return 1;
             }
             else if (anchor || tag) {
-                yaml_char_t *value = yaml_malloc(1);
+                yaml_char_t *value = YAML_MALLOC(1);
                 if (!value) {
                     parser->error = YAML_MEMORY_ERROR;
                     goto error;
@@ -759,9 +759,8 @@ yaml_parser_parse_block_sequence_entry(yaml_parser_t *parser,
 
     else if (token->type == YAML_BLOCK_END_TOKEN)
     {
-        yaml_mark_t dummy_mark;     /* Used to eliminate a compiler warning. */
         parser->state = POP(parser, parser->states);
-        dummy_mark = POP(parser, parser->marks);
+        (void)POP(parser, parser->marks);
         SEQUENCE_END_EVENT_INIT(*event, token->start_mark, token->end_mark);
         SKIP_TOKEN(parser);
         return 1;
@@ -869,9 +868,8 @@ yaml_parser_parse_block_mapping_key(yaml_parser_t *parser,
 
     else if (token->type == YAML_BLOCK_END_TOKEN)
     {
-        yaml_mark_t dummy_mark;     /* Used to eliminate a compiler warning. */
         parser->state = POP(parser, parser->states);
-        dummy_mark = POP(parser, parser->marks);
+        (void)POP(parser, parser->marks);
         MAPPING_END_EVENT_INIT(*event, token->start_mark, token->end_mark);
         SKIP_TOKEN(parser);
         return 1;
@@ -952,7 +950,6 @@ yaml_parser_parse_flow_sequence_entry(yaml_parser_t *parser,
         yaml_event_t *event, int first)
 {
     yaml_token_t *token;
-    yaml_mark_t dummy_mark;     /* Used to eliminate a compiler warning. */
 
     if (first) {
         token = PEEK_TOKEN(parser);
@@ -997,7 +994,7 @@ yaml_parser_parse_flow_sequence_entry(yaml_parser_t *parser,
     }
 
     parser->state = POP(parser, parser->states);
-    dummy_mark = POP(parser, parser->marks);
+    (void)POP(parser, parser->marks);
     SEQUENCE_END_EVENT_INIT(*event, token->start_mark, token->end_mark);
     SKIP_TOKEN(parser);
     return 1;
@@ -1104,7 +1101,6 @@ yaml_parser_parse_flow_mapping_key(yaml_parser_t *parser,
         yaml_event_t *event, int first)
 {
     yaml_token_t *token;
-    yaml_mark_t dummy_mark;     /* Used to eliminate a compiler warning. */
 
     if (first) {
         token = PEEK_TOKEN(parser);
@@ -1158,7 +1154,7 @@ yaml_parser_parse_flow_mapping_key(yaml_parser_t *parser,
     }
 
     parser->state = POP(parser, parser->states);
-    dummy_mark = POP(parser, parser->marks);
+    (void)POP(parser, parser->marks);
     MAPPING_END_EVENT_INIT(*event, token->start_mark, token->end_mark);
     SKIP_TOKEN(parser);
     return 1;
@@ -1212,7 +1208,7 @@ yaml_parser_process_empty_scalar(yaml_parser_t *parser, yaml_event_t *event,
 {
     yaml_char_t *value;
 
-    value = yaml_malloc(1);
+    value = YAML_MALLOC(1);
     if (!value) {
         parser->error = YAML_MEMORY_ERROR;
         return 0;
@@ -1249,7 +1245,7 @@ yaml_parser_process_directives(yaml_parser_t *parser,
     } tag_directives = { NULL, NULL, NULL };
     yaml_token_t *token;
 
-    if (!STACK_INIT(parser, tag_directives, INITIAL_STACK_SIZE))
+    if (!STACK_INIT(parser, tag_directives, yaml_tag_directive_t*))
         goto error;
 
     token = PEEK_TOKEN(parser);
@@ -1270,7 +1266,7 @@ yaml_parser_process_directives(yaml_parser_t *parser,
                         "found incompatible YAML document", token->start_mark);
                 goto error;
             }
-            version_directive = yaml_malloc(sizeof(yaml_version_directive_t));
+            version_directive = YAML_MALLOC_STATIC(yaml_version_directive_t);
             if (!version_directive) {
                 parser->error = YAML_MEMORY_ERROR;
                 goto error;

--- a/src/parser.c
+++ b/src/parser.c
@@ -179,8 +179,10 @@ yaml_parser_parse(yaml_parser_t *parser, yaml_event_t *event)
     /* No events after the end of the stream or error. */
 
     if (parser->stream_end_produced ||
-        parser->error ||
-        parser->state == YAML_PARSE_END_STATE) {
+        (parser->error &&
+           /* continue in nonstrict and READER_ERROR */
+           (!parser->problem_nonstrict || parser->error != YAML_READER_ERROR)) ||
+         parser->state == YAML_PARSE_END_STATE) {
         return 1;
     }
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -178,8 +178,9 @@ yaml_parser_parse(yaml_parser_t *parser, yaml_event_t *event)
 
     /* No events after the end of the stream or error. */
 
-    if (parser->stream_end_produced || parser->error ||
-            parser->state == YAML_PARSE_END_STATE) {
+    if (parser->stream_end_produced ||
+        parser->error ||
+        parser->state == YAML_PARSE_END_STATE) {
         return 1;
     }
 
@@ -390,7 +391,8 @@ yaml_parser_parse_document_start(yaml_parser_t *parser, yaml_event_t *event,
                     &tag_directives.start, &tag_directives.end))
             return 0;
         token = PEEK_TOKEN(parser);
-        if (!token) goto error;
+        if (!token)
+            goto error;
         if (token->type != YAML_DOCUMENT_START_TOKEN) {
             yaml_parser_set_parser_error(parser,
                     "did not find expected <document start>", token->start_mark);
@@ -560,7 +562,8 @@ yaml_parser_parse_node(yaml_parser_t *parser, yaml_event_t *event,
             end_mark = token->end_mark;
             SKIP_TOKEN(parser);
             token = PEEK_TOKEN(parser);
-            if (!token) goto error;
+            if (!token)
+                goto error;
             if (token->type == YAML_TAG_TOKEN)
             {
                 tag_handle = token->data.tag.handle;
@@ -569,7 +572,8 @@ yaml_parser_parse_node(yaml_parser_t *parser, yaml_event_t *event,
                 end_mark = token->end_mark;
                 SKIP_TOKEN(parser);
                 token = PEEK_TOKEN(parser);
-                if (!token) goto error;
+                if (!token)
+                    goto error;
             }
         }
         else if (token->type == YAML_TAG_TOKEN)
@@ -580,14 +584,16 @@ yaml_parser_parse_node(yaml_parser_t *parser, yaml_event_t *event,
             end_mark = token->end_mark;
             SKIP_TOKEN(parser);
             token = PEEK_TOKEN(parser);
-            if (!token) goto error;
+            if (!token)
+                goto error;
             if (token->type == YAML_ANCHOR_TOKEN)
             {
                 anchor = token->data.anchor.value;
                 end_mark = token->end_mark;
                 SKIP_TOKEN(parser);
                 token = PEEK_TOKEN(parser);
-                if (!token) goto error;
+                if (!token)
+                    goto error;
             }
         }
 
@@ -1249,7 +1255,8 @@ yaml_parser_process_directives(yaml_parser_t *parser,
         goto error;
 
     token = PEEK_TOKEN(parser);
-    if (!token) goto error;
+    if (!token)
+        goto error;
 
     while (token->type == YAML_VERSION_DIRECTIVE_TOKEN ||
             token->type == YAML_TAG_DIRECTIVE_TOKEN)
@@ -1289,7 +1296,8 @@ yaml_parser_process_directives(yaml_parser_t *parser,
 
         SKIP_TOKEN(parser);
         token = PEEK_TOKEN(parser);
-        if (!token) goto error;
+        if (!token)
+            goto error;
     }
     
     for (default_tag_directive = default_tag_directives;

--- a/src/reader.c
+++ b/src/reader.c
@@ -103,7 +103,8 @@ yaml_parser_update_raw_buffer(yaml_parser_t *parser)
 
     /* Return on EOF. */
 
-    if (parser->eof) return 1;
+    if (parser->eof)
+        return 1;
 
     /* Move the remaining bytes in the raw buffer to the beginning. */
 
@@ -183,7 +184,8 @@ yaml_parser_update_buffer(yaml_parser_t *parser, size_t length)
         /* Fill the raw buffer if necessary. */
 
         if (!first || parser->raw_buffer.pointer == parser->raw_buffer.last) {
-            if (!yaml_parser_update_raw_buffer(parser)) return 0;
+            if (!yaml_parser_update_raw_buffer(parser))
+                return 0;
         }
         first = 0;
 
@@ -343,7 +345,7 @@ yaml_parser_update_buffer(yaml_parser_t *parser, size_t length)
                     /* Get the character. */
 
                     value = parser->raw_buffer.pointer[low]
-                        + (parser->raw_buffer.pointer[high] << 8);
+                         + (parser->raw_buffer.pointer[high] << 8);
 
                     /* Check for unexpected low surrogate area. */
 
@@ -409,15 +411,15 @@ yaml_parser_update_buffer(yaml_parser_t *parser, size_t length)
              */
 
             if (! (value == 0x09 || value == 0x0A || value == 0x0D
-                        || (value >= 0x20 && value <= 0x7E)
-                        || (value == 0x85) || (value >= 0xA0 && value <= 0xD7FF)
-                        || (value >= 0xE000 && value <= 0xFFFD)
-                       || (value >= 0x10000 && value <= 0x10FFFF))) {
-                int err = yaml_parser_set_reader_error(parser,
-                              "control characters are not allowed",
-                              parser->offset, value);
+                   || (value >= 0x20 && value <= 0x7E)
+                   || (value == 0x85) || (value >= 0xA0 && value <= 0xD7FF)
+                   || (value >= 0xE000 && value <= 0xFFFD)
+                   || (value >= 0x10000 && value <= 0x10FFFF))) {
+                (void)yaml_parser_set_reader_error(parser,
+                           "control characters are not allowed",
+                           parser->offset, value);
                 if (!parser->problem_nonstrict)
-                    return err;
+                    return 0;
             }
 
             /* Move the raw pointers. */

--- a/src/reader.c
+++ b/src/reader.c
@@ -412,10 +412,13 @@ yaml_parser_update_buffer(yaml_parser_t *parser, size_t length)
                         || (value >= 0x20 && value <= 0x7E)
                         || (value == 0x85) || (value >= 0xA0 && value <= 0xD7FF)
                         || (value >= 0xE000 && value <= 0xFFFD)
-                        || (value >= 0x10000 && value <= 0x10FFFF)))
-                return yaml_parser_set_reader_error(parser,
-                        "control characters are not allowed",
-                        parser->offset, value);
+                       || (value >= 0x10000 && value <= 0x10FFFF))) {
+                int err = yaml_parser_set_reader_error(parser,
+                              "control characters are not allowed",
+                              parser->offset, value);
+                if (!parser->problem_nonstrict)
+                    return err;
+            }
 
             /* Move the raw pointers. */
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1195,11 +1195,9 @@ yaml_parser_increase_flow_level(yaml_parser_t *parser)
 static int
 yaml_parser_decrease_flow_level(yaml_parser_t *parser)
 {
-    yaml_simple_key_t dummy_key;    /* Used to eliminate a compiler warning. */
-
     if (parser->flow_level) {
         parser->flow_level --;
-        dummy_key = POP(parser, parser->simple_keys);
+        (void)POP(parser, parser->simple_keys);
     }
 
     return 1;
@@ -2410,7 +2408,7 @@ yaml_parser_scan_tag(yaml_parser_t *parser, yaml_token_t *token)
     {
         /* Set the handle to '' */
 
-        handle = yaml_malloc(1);
+        handle = YAML_MALLOC(1);
         if (!handle) goto error;
         handle[0] = '\0';
 
@@ -2462,7 +2460,7 @@ yaml_parser_scan_tag(yaml_parser_t *parser, yaml_token_t *token)
             /* Set the handle to '!'. */
 
             yaml_free(handle);
-            handle = yaml_malloc(2);
+            handle = YAML_MALLOC(2);
             if (!handle) goto error;
             handle[0] = '!';
             handle[1] = '\0';

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -3218,9 +3218,15 @@ yaml_parser_scan_flow_scalar(yaml_parser_t *parser, yaml_token_t *token,
                         break;
 
                     default:
-                        yaml_parser_set_scanner_error(parser, "while parsing a quoted scalar",
-                                start_mark, "found unknown escape character");
-                        goto error;
+                      yaml_parser_set_scanner_error(parser, "while parsing a quoted scalar",
+                                                    start_mark, "found unknown escape character");
+                      if (!parser->problem_nonstrict) {
+                          goto error;
+                      } else { /* all other parsers allow any quoted char, like \. in strings */
+                          parser->error = YAML_READER_ERROR; /* fake for the YAML_PARSE_END_STATE check */
+                          *(string.pointer++) = '\\';
+                          *(string.pointer++) = parser->buffer.pointer[1];
+                      }
                 }
 
                 SKIP(parser);

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -750,9 +750,9 @@ yaml_parser_scan(yaml_parser_t *parser, yaml_token_t *token)
 
     /* No tokens after STREAM-END or error. */
 
-    if (parser->stream_end_produced || parser->error) {
+    if (parser->stream_end_produced
+        || parser->error)
         return 1;
-    }
 
     /* Ensure that the tokens queue contains enough tokens. */
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -751,7 +751,9 @@ yaml_parser_scan(yaml_parser_t *parser, yaml_token_t *token)
     /* No tokens after STREAM-END or error. */
 
     if (parser->stream_end_produced
-        || parser->error)
+        || (parser->error
+            /* continue in nonstrict and READER_ERROR */
+            && (!parser->problem_nonstrict || parser->error != YAML_READER_ERROR)))
         return 1;
 
     /* Ensure that the tokens queue contains enough tokens. */

--- a/src/yaml_private.h
+++ b/src/yaml_private.h
@@ -90,7 +90,7 @@ yaml_parser_fetch_more_tokens(yaml_parser_t *parser);
  */
 
 #define BUFFER_INIT(context,buffer,size)                                        \
-    (((buffer).start = yaml_malloc(size)) ?                                     \
+  (((buffer).start = (yaml_char_t *)yaml_malloc(size)) ?                        \
         ((buffer).last = (buffer).pointer = (buffer).start,                     \
          (buffer).end = (buffer).start+(size),                                  \
          1) :                                                                   \
@@ -130,7 +130,7 @@ yaml_string_join(
      (value).pointer = (string))
 
 #define STRING_INIT(context,string,size)                                        \
-    (((string).start = yaml_malloc(size)) ?                                     \
+    (((string).start = YAML_MALLOC(size)) ?                                     \
         ((string).pointer = (string).start,                                     \
          (string).end = (string).start+(size),                                  \
          memset((string).start, 0, (size)),                                     \
@@ -420,10 +420,10 @@ yaml_stack_extend(void **start, void **top, void **end);
 YAML_DECLARE(int)
 yaml_queue_extend(void **start, void **head, void **tail, void **end);
 
-#define STACK_INIT(context,stack,size)                                          \
-    (((stack).start = yaml_malloc((size)*sizeof(*(stack).start))) ?             \
+#define STACK_INIT(context,stack,type)                                     \
+  (((stack).start = (type)yaml_malloc(INITIAL_STACK_SIZE*sizeof(*(stack).start))) ? \
         ((stack).top = (stack).start,                                           \
-         (stack).end = (stack).start+(size),                                    \
+         (stack).end = (stack).start+INITIAL_STACK_SIZE,                        \
          1) :                                                                   \
         ((context)->error = YAML_MEMORY_ERROR,                                  \
          0))
@@ -453,8 +453,8 @@ yaml_queue_extend(void **start, void **head, void **tail, void **end);
 #define POP(context,stack)                                                      \
     (*(--(stack).top))
 
-#define QUEUE_INIT(context,queue,size)                                          \
-    (((queue).start = yaml_malloc((size)*sizeof(*(queue).start))) ?             \
+#define QUEUE_INIT(context,queue,size,type)                                     \
+  (((queue).start = (type)yaml_malloc((size)*sizeof(*(queue).start))) ?         \
         ((queue).head = (queue).tail = (queue).start,                           \
          (queue).end = (queue).start+(size),                                    \
          1) :                                                                   \
@@ -658,3 +658,27 @@ yaml_queue_extend(void **start, void **head, void **tail, void **end);
      (node).data.mapping.pairs.top = (node_pairs_start),                        \
      (node).data.mapping.style = (node_style))
 
+/* Strict C compiler warning helpers */
+
+#if defined(__clang__) || defined(__GNUC__)
+#  define HASATTRIBUTE_UNUSED
+#endif
+#ifdef HASATTRIBUTE_UNUSED
+#  define __attribute__unused__             __attribute__((__unused__))
+#else
+#  define __attribute__unused__
+#endif
+
+/* Shim arguments are arguments that must be included in your function,
+ * but serve no purpose inside.  Silence compiler warnings. */
+#define SHIM(a) /*@unused@*/ a __attribute__unused__
+
+/* UNUSED_PARAM() marks a shim argument in the body to silence compiler warnings */
+#ifdef __clang__
+#  define UNUSED_PARAM(a) (void)(a);
+#else
+#  define UNUSED_PARAM(a) /*@-noeffect*/if (0) (void)(a)/*@=noeffect*/;
+#endif
+
+#define YAML_MALLOC_STATIC(type) (type*)yaml_malloc(sizeof(type))
+#define YAML_MALLOC(size)        (yaml_char_t *)yaml_malloc(size)

--- a/tests/example-deconstructor.c
+++ b/tests/example-deconstructor.c
@@ -1033,12 +1033,12 @@ parser_error:
 
         case YAML_READER_ERROR:
             if (parser.problem_value != -1) {
-                fprintf(stderr, "Reader error: %s: #%X at %d\n", parser.problem,
-                        parser.problem_value, parser.problem_offset);
+                fprintf(stderr, "Reader error: %s: #%X at %ld\n", parser.problem,
+                        parser.problem_value, (long)parser.problem_offset);
             }
             else {
-                fprintf(stderr, "Reader error: %s at %d\n", parser.problem,
-                        parser.problem_offset);
+                fprintf(stderr, "Reader error: %s at %ld\n", parser.problem,
+                        (long)parser.problem_offset);
             }
             break;
 
@@ -1046,14 +1046,14 @@ parser_error:
             if (parser.context) {
                 fprintf(stderr, "Scanner error: %s at line %d, column %d\n"
                         "%s at line %d, column %d\n", parser.context,
-                        parser.context_mark.line+1, parser.context_mark.column+1,
-                        parser.problem, parser.problem_mark.line+1,
-                        parser.problem_mark.column+1);
+                        (int)parser.context_mark.line+1, (int)parser.context_mark.column+1,
+                        parser.problem, (int)parser.problem_mark.line+1,
+                        (int)parser.problem_mark.column+1);
             }
             else {
                 fprintf(stderr, "Scanner error: %s at line %d, column %d\n",
-                        parser.problem, parser.problem_mark.line+1,
-                        parser.problem_mark.column+1);
+                        parser.problem, (int)parser.problem_mark.line+1,
+                        (int)parser.problem_mark.column+1);
             }
             break;
 
@@ -1061,14 +1061,14 @@ parser_error:
             if (parser.context) {
                 fprintf(stderr, "Parser error: %s at line %d, column %d\n"
                         "%s at line %d, column %d\n", parser.context,
-                        parser.context_mark.line+1, parser.context_mark.column+1,
-                        parser.problem, parser.problem_mark.line+1,
-                        parser.problem_mark.column+1);
+                        (int)parser.context_mark.line+1, (int)parser.context_mark.column+1,
+                        parser.problem, (int)parser.problem_mark.line+1,
+                        (int)parser.problem_mark.column+1);
             }
             else {
                 fprintf(stderr, "Parser error: %s at line %d, column %d\n",
-                        parser.problem, parser.problem_mark.line+1,
-                        parser.problem_mark.column+1);
+                        parser.problem, (int)parser.problem_mark.line+1,
+                        (int)parser.problem_mark.column+1);
             }
             break;
 

--- a/tests/example-reformatter.c
+++ b/tests/example-reformatter.c
@@ -120,12 +120,12 @@ parser_error:
 
         case YAML_READER_ERROR:
             if (parser.problem_value != -1) {
-                fprintf(stderr, "Reader error: %s: #%X at %d\n", parser.problem,
-                        parser.problem_value, parser.problem_offset);
+                fprintf(stderr, "Reader error: %s: #%X at %ld\n", parser.problem,
+                        parser.problem_value, (long)parser.problem_offset);
             }
             else {
-                fprintf(stderr, "Reader error: %s at %d\n", parser.problem,
-                        parser.problem_offset);
+                fprintf(stderr, "Reader error: %s at %ld\n", parser.problem,
+                        (long)parser.problem_offset);
             }
             break;
 
@@ -133,14 +133,14 @@ parser_error:
             if (parser.context) {
                 fprintf(stderr, "Scanner error: %s at line %d, column %d\n"
                         "%s at line %d, column %d\n", parser.context,
-                        parser.context_mark.line+1, parser.context_mark.column+1,
-                        parser.problem, parser.problem_mark.line+1,
-                        parser.problem_mark.column+1);
+                        (int)parser.context_mark.line+1, (int)parser.context_mark.column+1,
+                        parser.problem, (int)parser.problem_mark.line+1,
+                        (int)parser.problem_mark.column+1);
             }
             else {
                 fprintf(stderr, "Scanner error: %s at line %d, column %d\n",
-                        parser.problem, parser.problem_mark.line+1,
-                        parser.problem_mark.column+1);
+                        parser.problem, (int)parser.problem_mark.line+1,
+                        (int)parser.problem_mark.column+1);
             }
             break;
 
@@ -148,14 +148,14 @@ parser_error:
             if (parser.context) {
                 fprintf(stderr, "Parser error: %s at line %d, column %d\n"
                         "%s at line %d, column %d\n", parser.context,
-                        parser.context_mark.line+1, parser.context_mark.column+1,
-                        parser.problem, parser.problem_mark.line+1,
-                        parser.problem_mark.column+1);
+                        (int)parser.context_mark.line+1, (int)parser.context_mark.column+1,
+                        parser.problem, (int)parser.problem_mark.line+1,
+                        (int)parser.problem_mark.column+1);
             }
             else {
                 fprintf(stderr, "Parser error: %s at line %d, column %d\n",
-                        parser.problem, parser.problem_mark.line+1,
-                        parser.problem_mark.column+1);
+                        parser.problem, (int)parser.problem_mark.line+1,
+                        (int)parser.problem_mark.column+1);
             }
             break;
 

--- a/tests/run-dumper.c
+++ b/tests/run-dumper.c
@@ -179,8 +179,8 @@ int print_output(char *name, unsigned char *buffer, size_t size, int count)
         if (feof(file)) break;
     }
     fclose(file);
-    printf("#### (length: %d)\n", total_size);
-    printf("OUTPUT:\n%s#### (length: %d)\n", buffer, size);
+    printf("#### (length: %ld)\n", (long)total_size);
+    printf("OUTPUT:\n%s#### (length: %ld)\n", buffer, (long)size);
     return 0;
 }
 
@@ -303,7 +303,7 @@ main(int argc, char *argv[])
             yaml_document_delete(documents+k);
         }
 
-        printf("PASSED (length: %d)\n", written);
+        printf("PASSED (length: %ld)\n", (long)written);
         print_output(argv[number], buffer, written, -1);
     }
 

--- a/tests/run-emitter.c
+++ b/tests/run-emitter.c
@@ -205,8 +205,8 @@ int print_output(char *name, unsigned char *buffer, size_t size, int count)
         if (feof(file)) break;
     }
     fclose(file);
-    printf("#### (length: %d)\n", total_size);
-    printf("OUTPUT:\n%s#### (length: %d)\n", buffer, size);
+    printf("#### (length: %ld)\n", (long)total_size);
+    printf("OUTPUT:\n%s#### (length: %ld)\n", buffer, (long)size);
     return 0;
 }
 
@@ -319,7 +319,7 @@ main(int argc, char *argv[])
             yaml_event_delete(events+k);
         }
 
-        printf("PASSED (length: %d)\n", written);
+        printf("PASSED (length: %ld)\n", (long)written);
         print_output(argv[number], buffer, written, -1);
     }
 

--- a/tests/test-reader.c
+++ b/tests/test-reader.c
@@ -144,12 +144,12 @@ int check_utf8_sequences(void)
             }
             else if (parser.error == YAML_READER_ERROR) {
                 if (parser.problem_value != -1) {
-                    printf("(reader error: %s: #%X at %d)\n",
-                            parser.problem, parser.problem_value, parser.problem_offset);
+                    printf("(reader error: %s: #%X at %ld)\n",
+                            parser.problem, parser.problem_value, (long)parser.problem_offset);
                 }
                 else {
-                    printf("(reader error: %s at %d)\n",
-                            parser.problem, parser.problem_offset);
+                    printf("(reader error: %s at %ld)\n",
+                            parser.problem, (long)parser.problem_offset);
                 }
             }
             if (*end == '!') break;
@@ -180,12 +180,12 @@ int check_boms(void)
         yaml_parser_set_input_string(&parser, (unsigned char *)start, end-start);
         result = yaml_parser_update_buffer(&parser, end-start);
         if (!result) {
-            printf("- (reader error: %s at %d)\n", parser.problem, parser.problem_offset);
+            printf("- (reader error: %s at %ld)\n", parser.problem, (long)parser.problem_offset);
             failed++;
         }
         else {
             if (parser.unread != check) {
-                printf("- (length=%d while expected length=%d)\n", parser.unread, check);
+                printf("- (length=%ld while expected length=%d)\n", (long)parser.unread, check);
                 failed++;
             }
             else if (memcmp(parser.buffer.start, bom_original, check) != 0) {
@@ -211,7 +211,7 @@ int check_long_utf8(void)
     int j;
     int failed = 0;
     unsigned char ch0, ch1;
-    unsigned char *buffer = malloc(3+LONG*2);
+    unsigned char *buffer = (unsigned char *)malloc(3+LONG*2);
     assert(buffer);
     printf("checking a long utf8 sequence...\n");
     buffer[k++] = '\xef';
@@ -232,7 +232,7 @@ int check_long_utf8(void)
     for (k = 0; k < LONG; k++) {
         if (!parser.unread) {
             if (!yaml_parser_update_buffer(&parser, 1)) {
-                printf("\treader error: %s at %d\n", parser.problem, parser.problem_offset);
+              printf("\treader error: %s at %ld\n", parser.problem, (long)parser.problem_offset);
                 failed = 1;
                 break;
             }
@@ -262,11 +262,11 @@ int check_long_utf8(void)
     }
     if (!failed) {
         if (!yaml_parser_update_buffer(&parser, 1)) {
-            printf("\treader error: %s at %d\n", parser.problem, parser.problem_offset);
+            printf("\treader error: %s at %ld\n", parser.problem, (long)parser.problem_offset);
             failed = 1;
         }
         else if (parser.buffer.pointer[0] != '\0') {
-            printf("\texpected NUL, found %X (eof=%d, unread=%d)\n", (int)parser.buffer.pointer[0], parser.eof, parser.unread);
+            printf("\texpected NUL, found %X (eof=%d, unread=%ld)\n", (int)parser.buffer.pointer[0], parser.eof, (long)parser.unread);
             failed = 1;
         }
     }
@@ -283,7 +283,7 @@ int check_long_utf16(void)
     int j;
     int failed = 0;
     unsigned char ch0, ch1;
-    unsigned char *buffer = malloc(2+LONG*2);
+    unsigned char *buffer = (unsigned char *)malloc(2+LONG*2);
     assert(buffer);
     printf("checking a long utf16 sequence...\n");
     buffer[k++] = '\xff';
@@ -303,7 +303,7 @@ int check_long_utf16(void)
     for (k = 0; k < LONG; k++) {
         if (!parser.unread) {
             if (!yaml_parser_update_buffer(&parser, 1)) {
-                printf("\treader error: %s at %d\n", parser.problem, parser.problem_offset);
+              printf("\treader error: %s at %ld\n", parser.problem, (long)parser.problem_offset);
                 failed = 1;
                 break;
             }
@@ -333,11 +333,11 @@ int check_long_utf16(void)
     }
     if (!failed) {
         if (!yaml_parser_update_buffer(&parser, 1)) {
-            printf("\treader error: %s at %d\n", parser.problem, parser.problem_offset);
+            printf("\treader error: %s at %ld\n", parser.problem, (long)parser.problem_offset);
             failed = 1;
         }
         else if (parser.buffer.pointer[0] != '\0') {
-            printf("\texpected NUL, found %X (eof=%d, unread=%d)\n", (int)parser.buffer.pointer[0], parser.eof, parser.unread);
+            printf("\texpected NUL, found %X (eof=%d, unread=%ld)\n", (int)parser.buffer.pointer[0], parser.eof, (long)parser.unread);
             failed = 1;
         }
     }

--- a/tests/test-version.c
+++ b/tests/test-version.c
@@ -21,9 +21,9 @@ main(void)
     assert(strcmp(buf, yaml_get_version_string()) == 0);
 
     /* Print structure sizes. */
-    printf("sizeof(token) = %d\n", sizeof(yaml_token_t));
-    printf("sizeof(event) = %d\n", sizeof(yaml_event_t));
-    printf("sizeof(parser) = %d\n", sizeof(yaml_parser_t));
+    printf("sizeof(token) = %ld\n", (long)sizeof(yaml_token_t));
+    printf("sizeof(event) = %ld\n", (long)sizeof(yaml_event_t));
+    printf("sizeof(parser) = %ld\n", (long)sizeof(yaml_parser_t));
 
     return 0;
 }


### PR DESCRIPTION
repro:
  CFLAGS="-Wall -Wextra -Wunused-parameter -Wc++-compat" ./configure && make

which we use for perl, and libyaml is now included in cperl.
Tested with gcc-5 and clang-3.7

There are still a tons of format warnings (%d on 64bit) in
example-deconstructor.c which I skipped.