### PR TITLE
Use .gitignore instead of .hgignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-syntax: glob
 aclocal.m4
 autom4te.cache
 configure


### PR DESCRIPTION
Now that we've switched to git, let's use Git's ignore file instead of
Mercurial's.