### PR TITLE
Add support for `make test` and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,7 @@ compiler:
 - clang
 - gcc
 
-script: ./bootstrap && ./configure && make test
+script:
+- ./bootstrap
+- ./configure
+- make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: c
+
+compiler:
+- clang
+- gcc
+
+script: ./bootstrap && ./configure && make test

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,3 +16,5 @@ maintainer-clean-local:
 bootstrap: maintainer-clean
 	./bootstrap
 
+test: all
+	make -C tests check-TESTS


### PR DESCRIPTION
Currently this is not working on any environment we tried:

* ubuntu 16.04
* debian jessie
* definitely not on OSX.


