### PR TITLE
Patch to guard against integer overflow

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -117,7 +117,12 @@ yaml_string_join(
 YAML_DECLARE(int)
 yaml_stack_extend(void **start, void **top, void **end)
 {
-    void *new_start = yaml_realloc(*start, ((char *)*end - (char *)*start)*2);
+    void *new_start;
+
+    if ((char *)*end - (char *)*start >= INT_MAX / 2)
+	return 0;
+
+    new_start = yaml_realloc(*start, ((char *)*end - (char *)*start)*2);
 
     if (!new_start) return 0;
 


### PR DESCRIPTION
Originally from Ruby binding.
