### PR TITLE
Removed trailing-whitespaces

### DIFF
--- a/src/emitter.c
+++ b/src/emitter.c
@@ -517,7 +517,7 @@ yaml_emitter_emit_stream_start(yaml_emitter_t *emitter,
         if (emitter->best_width < 0) {
             emitter->best_width = INT_MAX;
         }
-        
+
         if (!emitter->line_break) {
             emitter->line_break = YAML_LN_BREAK;
         }
@@ -607,7 +607,7 @@ yaml_emitter_emit_document_start(yaml_emitter_t *emitter,
             if (!yaml_emitter_write_indent(emitter))
                 return 0;
         }
-        
+
         if (event->data.document_start.tag_directives.start
                 != event->data.document_start.tag_directives.end) {
             implicit = 0;
@@ -721,7 +721,7 @@ yaml_emitter_emit_document_end(yaml_emitter_t *emitter,
 }
 
 /*
- * 
+ *
  * Expect a flow item node.
  */
 
@@ -1402,7 +1402,7 @@ yaml_emitter_analyze_anchor(yaml_emitter_t *emitter,
 {
     size_t anchor_length;
     yaml_string_t string;
-    
+
     anchor_length = strlen((char *)anchor);
     STRING_ASSIGN(string, anchor, anchor_length);
 
@@ -2322,4 +2322,3 @@ yaml_emitter_write_folded_scalar(yaml_emitter_t *emitter,
 
     return 1;
 }
-

--- a/src/parser.c
+++ b/src/parser.c
@@ -1295,7 +1295,7 @@ yaml_parser_process_directives(yaml_parser_t *parser,
         token = PEEK_TOKEN(parser);
         if (!token) goto error;
     }
-    
+
     for (default_tag_directive = default_tag_directives;
             default_tag_directive->handle; default_tag_directive++) {
         if (!yaml_parser_append_tag_directive(parser, *default_tag_directive, 1,

--- a/src/reader.c
+++ b/src/reader.c
@@ -52,7 +52,7 @@ yaml_parser_determine_encoding(yaml_parser_t *parser)
 {
     /* Ensure that we had enough bytes in the raw buffer. */
 
-    while (!parser->eof 
+    while (!parser->eof
             && parser->raw_buffer.last - parser->raw_buffer.pointer < 3) {
         if (!yaml_parser_update_raw_buffer(parser)) {
             return 0;
@@ -295,7 +295,7 @@ yaml_parser_update_buffer(yaml_parser_t *parser, size_t length)
                                 parser->offset, value);
 
                     break;
-                
+
                 case YAML_UTF16LE_ENCODING:
                 case YAML_UTF16BE_ENCODING:
 
@@ -318,7 +318,7 @@ yaml_parser_update_buffer(yaml_parser_t *parser, size_t length)
                      *
                      * The following formulas are used for decoding
                      * and encoding characters using surrogate pairs:
-                     * 
+                     *
                      *  U  = U' + 0x10000   (0x01 00 00 <= U <= 0x10 FF FF)
                      *  U' = yyyyyyyyyyxxxxxxxxxx   (0 <= U' <= 0x0F FF FF)
                      *  W1 = 110110yyyyyyyyyy

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -762,7 +762,7 @@ yaml_parser_scan(yaml_parser_t *parser, yaml_token_t *token)
     }
 
     /* Fetch the next token from the queue. */
-    
+
     *token = DEQUEUE(parser, parser->tokens);
     parser->token_available = 0;
     parser->tokens_parsed ++;
@@ -1114,7 +1114,7 @@ yaml_parser_save_simple_key(yaml_parser_t *parser)
         yaml_simple_key_t simple_key;
         simple_key.possible = 1;
         simple_key.required = required;
-        simple_key.token_number = 
+        simple_key.token_number =
             parser->tokens_parsed + (parser->tokens.tail - parser->tokens.head);
         simple_key.mark = parser->mark;
 
@@ -1200,7 +1200,7 @@ yaml_parser_decrease_flow_level(yaml_parser_t *parser)
  * Push the current indentation level to the stack and set the new level
  * the current column is greater than the indentation level.  In this case,
  * append or insert the specified token into the token queue.
- * 
+ *
  */
 
 static int
@@ -1938,7 +1938,7 @@ yaml_parser_scan_to_next_token(yaml_parser_t *parser)
          *
          *  - in the flow context;
          *  - in the block context, but not at the beginning of the line or
-         *  after '-', '?', or ':' (complex value).  
+         *  after '-', '?', or ':' (complex value).
          */
 
         if (!CACHE(parser, 1)) return 0;
@@ -3007,7 +3007,7 @@ yaml_parser_scan_block_scalar_breaks(yaml_parser_t *parser,
             *indent = 1;
     }
 
-   return 1; 
+   return 1;
 }
 
 /*
@@ -3577,4 +3577,3 @@ error:
 
     return 0;
 }
-

--- a/src/writer.c
+++ b/src/writer.c
@@ -74,7 +74,7 @@ yaml_emitter_flush(yaml_emitter_t *emitter)
         unsigned int value;
         size_t k;
 
-        /* 
+        /*
          * See the "reader.c" code for more details on UTF-8 encoding.  Note
          * that we assume that the buffer contains a valid UTF-8 sequence.
          */

--- a/src/yaml_private.h
+++ b/src/yaml_private.h
@@ -1,4 +1,3 @@
-
 #if HAVE_CONFIG_H
 #include <config.h>
 #endif
@@ -242,9 +241,9 @@ yaml_string_join(
         (string).pointer[offset] <= (yaml_char_t) 'f') ?                        \
        ((string).pointer[offset] - (yaml_char_t) 'a' + 10) :                    \
        ((string).pointer[offset] - (yaml_char_t) '0'))
- 
+
 #define AS_HEX(string)  AS_HEX_AT((string),0)
- 
+
 /*
  * Check if the character is ASCII.
  */
@@ -657,4 +656,3 @@ yaml_queue_extend(void **start, void **head, void **tail, void **end);
      (node).data.mapping.pairs.end = (node_pairs_end),                          \
      (node).data.mapping.pairs.top = (node_pairs_start),                        \
      (node).data.mapping.style = (node_style))
-


### PR DESCRIPTION
I got formatter warnings with trailing-whitespaces on [psych](https://github.com/ruby/psych) and [ruby core](https://github.com/ruby/ruby) when I picked libyaml source code to bundle our projects.

I removed these trailing-whitespaces.

