### PR TITLE
Fix typo

### DIFF
--- a/src/loader.c
+++ b/src/loader.c
@@ -239,8 +239,8 @@ yaml_parser_register_anchor(yaml_parser_t *parser,
         if (strcmp((char *)alias_data->anchor, (char *)anchor) == 0) {
             yaml_free(anchor);
             return yaml_parser_set_composer_error_context(parser,
-                    "found duplicate anchor; first occurence",
-                    alias_data->mark, "second occurence", data.mark);
+                    "found duplicate anchor; first occurrence",
+                    alias_data->mark, "second occurrence", data.mark);
         }
     }
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -70,7 +70,7 @@
  *      %TAG    !yaml!  tag:yaml.org,2002:
  *      ---
  *
- * The correspoding sequence of tokens:
+ * The corresponding sequence of tokens:
  *
  *      STREAM-START(utf-8)
  *      VERSION-DIRECTIVE(1,1)

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1251,7 +1251,7 @@ yaml_parser_roll_indent(yaml_parser_t *parser, ptrdiff_t column,
 
 /*
  * Pop indentation levels from the indents stack until the current level
- * becomes less or equal to the column.  For each intendation level, append
+ * becomes less or equal to the column.  For each indentation level, append
  * the BLOCK-END token.
  */
 
@@ -1266,7 +1266,7 @@ yaml_parser_unroll_indent(yaml_parser_t *parser, ptrdiff_t column)
     if (parser->flow_level)
         return 1;
 
-    /* Loop through the intendation levels in the stack. */
+    /* Loop through the indentation levels in the stack. */
 
     while (parser->indent > column)
     {
@@ -2053,7 +2053,7 @@ yaml_parser_scan_directive(yaml_parser_t *parser, yaml_token_t *token)
     else
     {
         yaml_parser_set_scanner_error(parser, "while scanning a directive",
-                start_mark, "found uknown directive name");
+                start_mark, "found unknown directive name");
         goto error;
     }
 
@@ -2775,15 +2775,15 @@ yaml_parser_scan_block_scalar(yaml_parser_t *parser, yaml_token_t *token,
 
         if (IS_DIGIT(parser->buffer))
         {
-            /* Check that the intendation is greater than 0. */
+            /* Check that the indentation is greater than 0. */
 
             if (CHECK(parser->buffer, '0')) {
                 yaml_parser_set_scanner_error(parser, "while scanning a block scalar",
-                        start_mark, "found an intendation indicator equal to 0");
+                        start_mark, "found an indentation indicator equal to 0");
                 goto error;
             }
 
-            /* Get the intendation level and eat the indicator. */
+            /* Get the indentation level and eat the indicator. */
 
             increment = AS_DIGIT(parser->buffer);
 
@@ -2797,7 +2797,7 @@ yaml_parser_scan_block_scalar(yaml_parser_t *parser, yaml_token_t *token,
     {
         if (CHECK(parser->buffer, '0')) {
             yaml_parser_set_scanner_error(parser, "while scanning a block scalar",
-                    start_mark, "found an intendation indicator equal to 0");
+                    start_mark, "found an indentation indicator equal to 0");
             goto error;
         }
 
@@ -2847,7 +2847,7 @@ yaml_parser_scan_block_scalar(yaml_parser_t *parser, yaml_token_t *token,
 
     end_mark = parser->mark;
 
-    /* Set the intendation level if it was specified. */
+    /* Set the indentation level if it was specified. */
 
     if (increment) {
         indent = parser->indent >= 0 ? parser->indent+increment : increment;
@@ -2913,7 +2913,7 @@ yaml_parser_scan_block_scalar(yaml_parser_t *parser, yaml_token_t *token,
 
         if (!READ_LINE(parser, leading_break)) goto error;
 
-        /* Eat the following intendation spaces and line breaks. */
+        /* Eat the following indentation spaces and line breaks. */
 
         if (!yaml_parser_scan_block_scalar_breaks(parser,
                     &indent, &trailing_breaks, start_mark, &end_mark)) goto error;
@@ -2948,8 +2948,8 @@ error:
 }
 
 /*
- * Scan intendation spaces and line breaks for a block scalar.  Determine the
- * intendation level if needed.
+ * Scan indentation spaces and line breaks for a block scalar.  Determine the
+ * indentation level if needed.
  */
 
 static int
@@ -2961,11 +2961,11 @@ yaml_parser_scan_block_scalar_breaks(yaml_parser_t *parser,
 
     *end_mark = parser->mark;
 
-    /* Eat the intendation spaces and line breaks. */
+    /* Eat the indentation spaces and line breaks. */
 
     while (1)
     {
-        /* Eat the intendation spaces. */
+        /* Eat the indentation spaces. */
 
         if (!CACHE(parser, 1)) return 0;
 
@@ -2978,12 +2978,12 @@ yaml_parser_scan_block_scalar_breaks(yaml_parser_t *parser,
         if ((int)parser->mark.column > max_indent)
             max_indent = (int)parser->mark.column;
 
-        /* Check for a tab character messing the intendation. */
+        /* Check for a tab character messing the indentation. */
 
         if ((!*indent || (int)parser->mark.column < *indent)
                 && IS_TAB(parser->buffer)) {
             return yaml_parser_set_scanner_error(parser, "while scanning a block scalar",
-                    start_mark, "found a tab character where an intendation space is expected");
+                    start_mark, "found a tab character where an indentation space is expected");
         }
 
         /* Have we found a non-empty line? */
@@ -3508,12 +3508,12 @@ yaml_parser_scan_plain_scalar(yaml_parser_t *parser, yaml_token_t *token)
         {
             if (IS_BLANK(parser->buffer))
             {
-                /* Check for tab character that abuse intendation. */
+                /* Check for tab character that abuse indentation. */
 
                 if (leading_blanks && (int)parser->mark.column < indent
                         && IS_TAB(parser->buffer)) {
                     yaml_parser_set_scanner_error(parser, "while scanning a plain scalar",
-                            start_mark, "found a tab character that violate intendation");
+                            start_mark, "found a tab character that violate indentation");
                     goto error;
                 }
 
@@ -3546,7 +3546,7 @@ yaml_parser_scan_plain_scalar(yaml_parser_t *parser, yaml_token_t *token)
             if (!CACHE(parser, 1)) goto error;
         }
 
-        /* Check intendation level. */
+        /* Check indentation level. */
 
         if (!parser->flow_level && (int)parser->mark.column < indent)
             break;


### PR DESCRIPTION
I picked from typo fixes from https://github.com/ruby/psych/commit/66fb7fb77533d0606748940288858794752d95cb