### PR TITLE
Added missing Cflags path in pkg-config file

### DIFF
--- a/yaml-0.1.pc.in
+++ b/yaml-0.1.pc.in
@@ -6,5 +6,5 @@ libdir=@libdir@
 Name: LibYAML
 Description: Library to parse and emit YAML
 Version: @PACKAGE_VERSION@
-Cflags:
+Cflags: -I${includedir}
 Libs: -L${libdir} -lyaml


### PR DESCRIPTION
The `Cflags` option in the pkg-config file is missing the include path. For systems like homebrew on macOS, this makes using pkg-config to compile impossible because of packages installed in non-standard paths.