### PR TITLE
add unit tests to cmake configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,8 @@ script:
 - ./bootstrap
 - ./configure
 - make test
+- make distclean
+- cmake .
+- make
+- make test
+- make clean

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,3 +14,12 @@ include_directories (include win32)
 add_definitions (-DHAVE_CONFIG_H -DYAML_DECLARE_STATIC)
 add_library (yaml STATIC ${SRC})
 
+add_executable (test-version tests/test-version.c)
+target_link_libraries(test-version yaml)
+add_test(NAME version COMMAND test-version)
+
+add_executable (test-reader tests/test-reader.c)
+target_link_libraries(test-reader yaml)
+add_test(NAME reader COMMAND test-reader)
+
+enable_testing()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,12 @@
+version: 0.1.7.{build}
+
+image:
+- Visual Studio 2015
+- Visual Studio 2013
+
+build_script:
+- cmake .
+- cmake --build . --config release --clean-first
+- ctest -C release
+- C:\cygwin\bin\sh -c "export PATH=/usr/bin:/usr/local/bin:$PATH && ./bootstrap && ./configure && make && make test && make distclean"
+- C:\cygwin64\bin\sh -c "export PATH=/usr/bin:/usr/local/bin:$PATH && ./bootstrap && ./configure && make && make test && make distclean"


### PR DESCRIPTION
Changes in this patch:

-  add the two unit tests executables to the cmake config file
- run the cmake build and tests under travis right after the autoconf build
- run the cmake (VS), cygwin-32 and cygwin-64 build and tests under appveyor for win32