### PR TITLE
Fix -Wformat compilation errors in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+os:
+- linux
+- osx
+
 language: c
 
 compiler:

--- a/tests/example-deconstructor-alt.c
+++ b/tests/example-deconstructor-alt.c
@@ -703,25 +703,25 @@ parser_error:
 
         case YAML_READER_ERROR:
             if (parser.problem_value != -1) {
-                fprintf(stderr, "Reader error: %s: #%X at %d\n", parser.problem,
+                fprintf(stderr, "Reader error: %s: #%X at %zd\n", parser.problem,
                         parser.problem_value, parser.problem_offset);
             }
             else {
-                fprintf(stderr, "Reader error: %s at %d\n", parser.problem,
+                fprintf(stderr, "Reader error: %s at %zd\n", parser.problem,
                         parser.problem_offset);
             }
             break;
 
         case YAML_SCANNER_ERROR:
             if (parser.context) {
-                fprintf(stderr, "Scanner error: %s at line %d, column %d\n"
-                        "%s at line %d, column %d\n", parser.context,
+                fprintf(stderr, "Scanner error: %s at line %lu, column %lu\n"
+                        "%s at line %lu, column %lu\n", parser.context,
                         parser.context_mark.line+1, parser.context_mark.column+1,
                         parser.problem, parser.problem_mark.line+1,
                         parser.problem_mark.column+1);
             }
             else {
-                fprintf(stderr, "Scanner error: %s at line %d, column %d\n",
+                fprintf(stderr, "Scanner error: %s at line %lu, column %lu\n",
                         parser.problem, parser.problem_mark.line+1,
                         parser.problem_mark.column+1);
             }
@@ -729,14 +729,14 @@ parser_error:
 
         case YAML_PARSER_ERROR:
             if (parser.context) {
-                fprintf(stderr, "Parser error: %s at line %d, column %d\n"
-                        "%s at line %d, column %d\n", parser.context,
+                fprintf(stderr, "Parser error: %s at line %lu, column %lu\n"
+                        "%s at line %lu, column %lu\n", parser.context,
                         parser.context_mark.line+1, parser.context_mark.column+1,
                         parser.problem, parser.problem_mark.line+1,
                         parser.problem_mark.column+1);
             }
             else {
-                fprintf(stderr, "Parser error: %s at line %d, column %d\n",
+                fprintf(stderr, "Parser error: %s at line %lu, column %lu\n",
                         parser.problem, parser.problem_mark.line+1,
                         parser.problem_mark.column+1);
             }

--- a/tests/example-deconstructor.c
+++ b/tests/example-deconstructor.c
@@ -1033,25 +1033,25 @@ parser_error:
 
         case YAML_READER_ERROR:
             if (parser.problem_value != -1) {
-                fprintf(stderr, "Reader error: %s: #%X at %d\n", parser.problem,
+                fprintf(stderr, "Reader error: %s: #%X at %zu\n", parser.problem,
                         parser.problem_value, parser.problem_offset);
             }
             else {
-                fprintf(stderr, "Reader error: %s at %d\n", parser.problem,
+                fprintf(stderr, "Reader error: %s at %zu\n", parser.problem,
                         parser.problem_offset);
             }
             break;
 
         case YAML_SCANNER_ERROR:
             if (parser.context) {
-                fprintf(stderr, "Scanner error: %s at line %d, column %d\n"
-                        "%s at line %d, column %d\n", parser.context,
+                fprintf(stderr, "Scanner error: %s at line %lu, column %lu\n"
+                        "%s at line %lu, column %lu\n", parser.context,
                         parser.context_mark.line+1, parser.context_mark.column+1,
                         parser.problem, parser.problem_mark.line+1,
                         parser.problem_mark.column+1);
             }
             else {
-                fprintf(stderr, "Scanner error: %s at line %d, column %d\n",
+                fprintf(stderr, "Scanner error: %s at line %lu, column %lu\n",
                         parser.problem, parser.problem_mark.line+1,
                         parser.problem_mark.column+1);
             }
@@ -1059,14 +1059,14 @@ parser_error:
 
         case YAML_PARSER_ERROR:
             if (parser.context) {
-                fprintf(stderr, "Parser error: %s at line %d, column %d\n"
-                        "%s at line %d, column %d\n", parser.context,
+                fprintf(stderr, "Parser error: %s at line %lu, column %lu\n"
+                        "%s at line %lu, column %lu\n", parser.context,
                         parser.context_mark.line+1, parser.context_mark.column+1,
                         parser.problem, parser.problem_mark.line+1,
                         parser.problem_mark.column+1);
             }
             else {
-                fprintf(stderr, "Parser error: %s at line %d, column %d\n",
+                fprintf(stderr, "Parser error: %s at line %lu, column %lu\n",
                         parser.problem, parser.problem_mark.line+1,
                         parser.problem_mark.column+1);
             }

--- a/tests/example-reformatter-alt.c
+++ b/tests/example-reformatter-alt.c
@@ -120,25 +120,25 @@ parser_error:
 
         case YAML_READER_ERROR:
             if (parser.problem_value != -1) {
-                fprintf(stderr, "Reader error: %s: #%X at %d\n", parser.problem,
+                fprintf(stderr, "Reader error: %s: #%X at %zd\n", parser.problem,
                         parser.problem_value, parser.problem_offset);
             }
             else {
-                fprintf(stderr, "Reader error: %s at %d\n", parser.problem,
+                fprintf(stderr, "Reader error: %s at %lu\n", parser.problem,
                         parser.problem_offset);
             }
             break;
 
         case YAML_SCANNER_ERROR:
             if (parser.context) {
-                fprintf(stderr, "Scanner error: %s at line %d, column %d\n"
-                        "%s at line %d, column %d\n", parser.context,
+                fprintf(stderr, "Scanner error: %s at line %lu, column %lu\n"
+                        "%s at line %lu, column %lu\n", parser.context,
                         parser.context_mark.line+1, parser.context_mark.column+1,
                         parser.problem, parser.problem_mark.line+1,
                         parser.problem_mark.column+1);
             }
             else {
-                fprintf(stderr, "Scanner error: %s at line %d, column %d\n",
+                fprintf(stderr, "Scanner error: %s at line %lu, column %lu\n",
                         parser.problem, parser.problem_mark.line+1,
                         parser.problem_mark.column+1);
             }
@@ -146,14 +146,14 @@ parser_error:
 
         case YAML_PARSER_ERROR:
             if (parser.context) {
-                fprintf(stderr, "Parser error: %s at line %d, column %d\n"
-                        "%s at line %d, column %d\n", parser.context,
+                fprintf(stderr, "Parser error: %s at line %lu, column %lu\n"
+                        "%s at line %lu, column %lu\n", parser.context,
                         parser.context_mark.line+1, parser.context_mark.column+1,
                         parser.problem, parser.problem_mark.line+1,
                         parser.problem_mark.column+1);
             }
             else {
-                fprintf(stderr, "Parser error: %s at line %d, column %d\n",
+                fprintf(stderr, "Parser error: %s at line %lu, column %lu\n",
                         parser.problem, parser.problem_mark.line+1,
                         parser.problem_mark.column+1);
             }
@@ -161,14 +161,14 @@ parser_error:
 
         case YAML_COMPOSER_ERROR:
             if (parser.context) {
-                fprintf(stderr, "Composer error: %s at line %d, column %d\n"
-                        "%s at line %d, column %d\n", parser.context,
+                fprintf(stderr, "Composer error: %s at line %lu, column %lu\n"
+                        "%s at line %lu, column %lu\n", parser.context,
                         parser.context_mark.line+1, parser.context_mark.column+1,
                         parser.problem, parser.problem_mark.line+1,
                         parser.problem_mark.column+1);
             }
             else {
-                fprintf(stderr, "Composer error: %s at line %d, column %d\n",
+                fprintf(stderr, "Composer error: %s at line %lu, column %lu\n",
                         parser.problem, parser.problem_mark.line+1,
                         parser.problem_mark.column+1);
             }

--- a/tests/example-reformatter.c
+++ b/tests/example-reformatter.c
@@ -120,25 +120,25 @@ parser_error:
 
         case YAML_READER_ERROR:
             if (parser.problem_value != -1) {
-                fprintf(stderr, "Reader error: %s: #%X at %d\n", parser.problem,
+                fprintf(stderr, "Reader error: %s: #%X at %zd\n", parser.problem,
                         parser.problem_value, parser.problem_offset);
             }
             else {
-                fprintf(stderr, "Reader error: %s at %d\n", parser.problem,
+                fprintf(stderr, "Reader error: %s at %zd\n", parser.problem,
                         parser.problem_offset);
             }
             break;
 
         case YAML_SCANNER_ERROR:
             if (parser.context) {
-                fprintf(stderr, "Scanner error: %s at line %d, column %d\n"
-                        "%s at line %d, column %d\n", parser.context,
+                fprintf(stderr, "Scanner error: %s at line %lu, column %lu\n"
+                        "%s at line %lu, column %lu\n", parser.context,
                         parser.context_mark.line+1, parser.context_mark.column+1,
                         parser.problem, parser.problem_mark.line+1,
                         parser.problem_mark.column+1);
             }
             else {
-                fprintf(stderr, "Scanner error: %s at line %d, column %d\n",
+                fprintf(stderr, "Scanner error: %s at line %lu, column %lu\n",
                         parser.problem, parser.problem_mark.line+1,
                         parser.problem_mark.column+1);
             }
@@ -146,14 +146,14 @@ parser_error:
 
         case YAML_PARSER_ERROR:
             if (parser.context) {
-                fprintf(stderr, "Parser error: %s at line %d, column %d\n"
-                        "%s at line %d, column %d\n", parser.context,
+                fprintf(stderr, "Parser error: %s at line %lu, column %lu\n"
+                        "%s at line %lu, column %lu\n", parser.context,
                         parser.context_mark.line+1, parser.context_mark.column+1,
                         parser.problem, parser.problem_mark.line+1,
                         parser.problem_mark.column+1);
             }
             else {
-                fprintf(stderr, "Parser error: %s at line %d, column %d\n",
+                fprintf(stderr, "Parser error: %s at line %lu, column %lu\n",
                         parser.problem, parser.problem_mark.line+1,
                         parser.problem_mark.column+1);
             }

--- a/tests/run-dumper.c
+++ b/tests/run-dumper.c
@@ -180,8 +180,8 @@ int print_output(char *name, unsigned char *buffer, size_t size, int count)
         if (feof(file)) break;
     }
     fclose(file);
-    printf("#### (length: %d)\n", total_size);
-    printf("OUTPUT:\n%s#### (length: %d)\n", buffer, size);
+    printf("#### (length: %zd)\n", total_size);
+    printf("OUTPUT:\n%s#### (length: %zd)\n", buffer, size);
     return 0;
 }
 
@@ -304,7 +304,7 @@ main(int argc, char *argv[])
             yaml_document_delete(documents+k);
         }
 
-        printf("PASSED (length: %d)\n", written);
+        printf("PASSED (length: %zd)\n", written);
         print_output(argv[number], buffer, written, -1);
     }
 

--- a/tests/run-emitter.c
+++ b/tests/run-emitter.c
@@ -205,8 +205,8 @@ int print_output(char *name, unsigned char *buffer, size_t size, int count)
         if (feof(file)) break;
     }
     fclose(file);
-    printf("#### (length: %d)\n", total_size);
-    printf("OUTPUT:\n%s#### (length: %d)\n", buffer, size);
+    printf("#### (length: %zd)\n", total_size);
+    printf("OUTPUT:\n%s#### (length: %zd)\n", buffer, size);
     return 0;
 }
 
@@ -319,7 +319,7 @@ main(int argc, char *argv[])
             yaml_event_delete(events+k);
         }
 
-        printf("PASSED (length: %d)\n", written);
+        printf("PASSED (length: %zd)\n", written);
         print_output(argv[number], buffer, written, -1);
     }
 

--- a/tests/test-reader.c
+++ b/tests/test-reader.c
@@ -144,11 +144,11 @@ int check_utf8_sequences(void)
             }
             else if (parser.error == YAML_READER_ERROR) {
                 if (parser.problem_value != -1) {
-                    printf("(reader error: %s: #%X at %d)\n",
+                    printf("(reader error: %s: #%X at %zu)\n",
                             parser.problem, parser.problem_value, parser.problem_offset);
                 }
                 else {
-                    printf("(reader error: %s at %d)\n",
+                    printf("(reader error: %s at %zu)\n",
                             parser.problem, parser.problem_offset);
                 }
             }
@@ -180,12 +180,12 @@ int check_boms(void)
         yaml_parser_set_input_string(&parser, (unsigned char *)start, end-start);
         result = yaml_parser_update_buffer(&parser, end-start);
         if (!result) {
-            printf("- (reader error: %s at %d)\n", parser.problem, parser.problem_offset);
+            printf("- (reader error: %s at %zu)\n", parser.problem, parser.problem_offset);
             failed++;
         }
         else {
             if (parser.unread != check) {
-                printf("- (length=%d while expected length=%d)\n", parser.unread, check);
+                printf("- (length=%zu while expected length=%d)\n", parser.unread, check);
                 failed++;
             }
             else if (memcmp(parser.buffer.start, bom_original, check) != 0) {
@@ -232,7 +232,7 @@ int check_long_utf8(void)
     for (k = 0; k < LONG; k++) {
         if (!parser.unread) {
             if (!yaml_parser_update_buffer(&parser, 1)) {
-                printf("\treader error: %s at %d\n", parser.problem, parser.problem_offset);
+                printf("\treader error: %s at %zu\n", parser.problem, parser.problem_offset);
                 failed = 1;
                 break;
             }
@@ -262,11 +262,11 @@ int check_long_utf8(void)
     }
     if (!failed) {
         if (!yaml_parser_update_buffer(&parser, 1)) {
-            printf("\treader error: %s at %d\n", parser.problem, parser.problem_offset);
+            printf("\treader error: %s at %zu\n", parser.problem, parser.problem_offset);
             failed = 1;
         }
         else if (parser.buffer.pointer[0] != '\0') {
-            printf("\texpected NUL, found %X (eof=%d, unread=%d)\n", (int)parser.buffer.pointer[0], parser.eof, parser.unread);
+            printf("\texpected NUL, found %X (eof=%d, unread=%zu)\n", (int)parser.buffer.pointer[0], parser.eof, parser.unread);
             failed = 1;
         }
     }
@@ -303,7 +303,7 @@ int check_long_utf16(void)
     for (k = 0; k < LONG; k++) {
         if (!parser.unread) {
             if (!yaml_parser_update_buffer(&parser, 1)) {
-                printf("\treader error: %s at %d\n", parser.problem, parser.problem_offset);
+                printf("\treader error: %s at %zu\n", parser.problem, parser.problem_offset);
                 failed = 1;
                 break;
             }
@@ -333,11 +333,11 @@ int check_long_utf16(void)
     }
     if (!failed) {
         if (!yaml_parser_update_buffer(&parser, 1)) {
-            printf("\treader error: %s at %d\n", parser.problem, parser.problem_offset);
+            printf("\treader error: %s at %zu\n", parser.problem, parser.problem_offset);
             failed = 1;
         }
         else if (parser.buffer.pointer[0] != '\0') {
-            printf("\texpected NUL, found %X (eof=%d, unread=%d)\n", (int)parser.buffer.pointer[0], parser.eof, parser.unread);
+            printf("\texpected NUL, found %X (eof=%d, unread=%zu)\n", (int)parser.buffer.pointer[0], parser.eof, parser.unread);
             failed = 1;
         }
     }

--- a/tests/test-version.c
+++ b/tests/test-version.c
@@ -21,9 +21,9 @@ main(void)
     assert(strcmp(buf, yaml_get_version_string()) == 0);
 
     /* Print structure sizes. */
-    printf("sizeof(token) = %d\n", sizeof(yaml_token_t));
-    printf("sizeof(event) = %d\n", sizeof(yaml_event_t));
-    printf("sizeof(parser) = %d\n", sizeof(yaml_parser_t));
+    printf("sizeof(token) = %lu\n", sizeof(yaml_token_t));
+    printf("sizeof(event) = %lu\n", sizeof(yaml_event_t));
+    printf("sizeof(parser) = %lu\n", sizeof(yaml_parser_t));
 
     return 0;
 }


### PR DESCRIPTION
There were several warnings generated by formatting errors in the tests,
this corrects the format strings and silences the warnings.