### PR TITLE
Update bug report URL in LibYAML

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@
 m4_define([YAML_MAJOR], 0)
 m4_define([YAML_MINOR], 1)
 m4_define([YAML_PATCH], 7)
-m4_define([YAML_BUGS], [https://bitbucket.org/xi/libyaml/issues/new])
+m4_define([YAML_BUGS], [https://github.com/yaml/libyaml/issues/new])
 
 # Define the libtool version numbers; check the Autobook, Section 11.4.
 # Bump the libtool version numbers using the following algorithm:


### PR DESCRIPTION
Previously we pointed at BitBucket, but we're using GitHub now, so we
should update that.