### PR TITLE
Use AM_CPPFLAGS since autotools deprecated INCLUDE

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,11 +1,11 @@
-INCLUDES = yaml.h
+AM_CPPFLAGS = yaml.h
 DOXYGEN_CFG = $(top_srcdir)/doc/doxygen.cfg
 
-nobase_include_HEADERS = $(INCLUDES)
+nobase_include_HEADERS = $(AM_CPPFLAGS)
 
 if DOXYGEN
 
-html: $(INCLUDES) $(DOXYGEN_CFG)
+html: $(AM_CPPFLAGS) $(DOXYGEN_CFG)
 	PACKAGE=$(PACKAGE) VERSION=$(VERSION) top_srcdir=$(top_srcdir) top_builddir=$(top_builddir) doxygen $(DOXYGEN_CFG)
 
 endif


### PR DESCRIPTION
autoconf deprecated INCLUDE around version 2.69. No other automake file
in the project uses INCLUDE (instead they use AM_CPPFLAGS) and this
warning prevents the bootstrap-configure-make process from working on
OSX for me. Updating the variable name in the include/Makefile.am fixes
this and allows me to move along with development on OSX.