### PR TITLE
Add travis and Makefile support for libyaml-test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ compiler:
 script:
 - ./bootstrap
 - ./configure
-- make test
+- make test-all
 - make distclean
 - cmake .
 - make

--- a/Makefile.am
+++ b/Makefile.am
@@ -12,9 +12,20 @@ maintainer-clean-local:
 	-rm -f aclocal.m4 config.h.in configure config/*
 	-find ${builddir} -name Makefile.in -exec rm -f '{}' ';'
 
+distclean-local:
+	-rm -fr libyaml-test
+
 .PHONY: bootstrap
 bootstrap: maintainer-clean
 	./bootstrap
 
 test: all
 	make -C tests check-TESTS
+
+test-suite: libyaml-test
+	(export LIBYAML_DIR=$$PWD; make -C $< test)
+
+libyaml-test:
+	git clone https://github.com/yaml/$@
+
+test-all: test test-suite


### PR DESCRIPTION
https://github.com/yaml/libyaml-test/ is a test runner that builds:

* https://github.com/ingydotnet/libyaml-parser/
* https://github.com/ingydotnet/libyaml-emitter/

And runs them against the tests defined in:

https://github.com/yaml/yaml-test-suite/

