### PR TITLE
Add Dockerfile for Fedora 25

### DIFF
--- a/dockerfiles/fedora-25
+++ b/dockerfiles/fedora-25
@@ -1,0 +1,23 @@
+# vim: ft=dockerfile
+FROM fedora:25
+MAINTAINER Ian Cordasco <graffatcolmingov@gmail.com>
+
+# NOTE(sigmavirus24): We need "perl-core" here for the "prove" binary
+# required by the test-all Makefile target
+RUN dnf install -y \
+    automake \
+    gcc \
+    git \
+    make \
+    libtool \
+    perl-core
+
+RUN mkdir /libyaml
+COPY . /libyaml/
+WORKDIR /libyaml
+
+RUN ./bootstrap
+RUN ./configure
+RUN make
+RUN make install
+CMD ["bash"]


### PR DESCRIPTION
This adds a Fedora 25 Dockerfile so we can start running SemaphoreCI on something other than a Debian variant.

This also includes preparatory work for the new work in #41 (installing `perl-core` to get the `prove` binary).