### PR TITLE
README: Update libyaml link

### DIFF
--- a/README
+++ b/README
@@ -12,7 +12,7 @@ $ make
 # make install
 
 For more information, check the LibYAML homepage:
-'http://pyyaml.org/wiki/LibYAML'.
+'https://github.com/yaml/libyaml'.
 
 Post your questions and opinions to the YAML-Core mailing list:
 'http://lists.sourceforge.net/lists/listinfo/yaml-core'.


### PR DESCRIPTION
Update the link to point where libyaml is now maintained. Per the old link, "LibYAML is now maintained at https://github.com/yaml/libyaml. This page is left for historical purposes."