### PR TITLE
Simplified conditions

### DIFF
--- a/tests/run-dumper.c
+++ b/tests/run-dumper.c
@@ -130,8 +130,7 @@ int compare_documents(yaml_document_t *document1, yaml_document_t *document2)
 {
     int k;
 
-    if ((document1->version_directive && !document2->version_directive)
-            || (!document1->version_directive && document2->version_directive)
+    if ((document1->version_directive != document2->version_directive)
             || (document1->version_directive && document2->version_directive
                 && (document1->version_directive->major != document2->version_directive->major
                     || document1->version_directive->minor != document2->version_directive->minor)))

--- a/tests/run-emitter.c
+++ b/tests/run-emitter.c
@@ -90,8 +90,7 @@ int compare_events(yaml_event_t *event1, yaml_event_t *event2)
                     event2->data.stream_start.encoding); */
 
         case YAML_DOCUMENT_START_EVENT:
-            if ((event1->data.document_start.version_directive && !event2->data.document_start.version_directive)
-                    || (!event1->data.document_start.version_directive && event2->data.document_start.version_directive)
+            if ((event1->data.document_start.version_directive != event2->data.document_start.version_directive)
                     || (event1->data.document_start.version_directive && event2->data.document_start.version_directive
                         && (event1->data.document_start.version_directive->major != event2->data.document_start.version_directive->major
                             || event1->data.document_start.version_directive->minor != event2->data.document_start.version_directive->minor)))
@@ -120,8 +119,7 @@ int compare_events(yaml_event_t *event1, yaml_event_t *event2)
                         (char *)event2->data.alias.anchor) == 0);
 
         case YAML_SCALAR_EVENT:
-            if ((event1->data.scalar.anchor && !event2->data.scalar.anchor)
-                    || (!event1->data.scalar.anchor && event2->data.scalar.anchor)
+            if ((event1->data.scalar.anchor != event2->data.scalar.anchor)
                     || (event1->data.scalar.anchor && event2->data.scalar.anchor
                         && strcmp((char *)event1->data.scalar.anchor,
                             (char *)event2->data.scalar.anchor) != 0))
@@ -139,20 +137,18 @@ int compare_events(yaml_event_t *event1, yaml_event_t *event2)
                         event1->data.scalar.length) != 0)
                 return 0;
             if ((event1->data.scalar.plain_implicit != event2->data.scalar.plain_implicit)
-                    || (event2->data.scalar.quoted_implicit != event2->data.scalar.quoted_implicit)
+                    || (event1->data.scalar.quoted_implicit != event2->data.scalar.quoted_implicit)
                     /* || (event2->data.scalar.style != event2->data.scalar.style) */)
                 return 0;
             return 1;
 
         case YAML_SEQUENCE_START_EVENT:
-            if ((event1->data.sequence_start.anchor && !event2->data.sequence_start.anchor)
-                    || (!event1->data.sequence_start.anchor && event2->data.sequence_start.anchor)
+            if ((event1->data.sequence_start.anchor != event2->data.sequence_start.anchor)
                     || (event1->data.sequence_start.anchor && event2->data.sequence_start.anchor
                         && strcmp((char *)event1->data.sequence_start.anchor,
                             (char *)event2->data.sequence_start.anchor) != 0))
                 return 0;
-            if ((event1->data.sequence_start.tag && !event2->data.sequence_start.tag)
-                    || (!event1->data.sequence_start.tag && event2->data.sequence_start.tag)
+            if ((event1->data.sequence_start.tag != event2->data.sequence_start.tag)
                     || (event1->data.sequence_start.tag && event2->data.sequence_start.tag
                         && strcmp((char *)event1->data.sequence_start.tag,
                             (char *)event2->data.sequence_start.tag) != 0))
@@ -163,14 +159,12 @@ int compare_events(yaml_event_t *event1, yaml_event_t *event2)
             return 1;
 
         case YAML_MAPPING_START_EVENT:
-            if ((event1->data.mapping_start.anchor && !event2->data.mapping_start.anchor)
-                    || (!event1->data.mapping_start.anchor && event2->data.mapping_start.anchor)
+            if ((event1->data.mapping_start.anchor != event2->data.mapping_start.anchor)
                     || (event1->data.mapping_start.anchor && event2->data.mapping_start.anchor
                         && strcmp((char *)event1->data.mapping_start.anchor,
                             (char *)event2->data.mapping_start.anchor) != 0))
                 return 0;
-            if ((event1->data.mapping_start.tag && !event2->data.mapping_start.tag)
-                    || (!event1->data.mapping_start.tag && event2->data.mapping_start.tag)
+            if ((event1->data.mapping_start.tag != event2->data.mapping_start.tag)
                     || (event1->data.mapping_start.tag && event2->data.mapping_start.tag
                         && strcmp((char *)event1->data.mapping_start.tag,
                             (char *)event2->data.mapping_start.tag) != 0))


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. Warnings, found using PVS-Studio:
libyaml/tests/run-emitter.c 93      warn    V728 An excessive check can be simplified. The '(A && !B) || (!A && B)' expression is equivalent to the 'bool(A) != bool(B)' expression.
libyaml/tests/run-emitter.c 123     warn    V728 An excessive check can be simplified. The '(A && !B) || (!A && B)' expression is equivalent to the 'bool(A) != bool(B)' expression.
libyaml/tests/run-emitter.c 142     err     V501 There are identical sub-expressions 'event2->data.scalar.quoted_implicit' to the left and to the right of the '!=' operator.
libyaml/tests/run-emitter.c 142     warn    V560 A part of conditional expression is always false.
libyaml/tests/run-emitter.c 148     warn    V728 An excessive check can be simplified. The '(A && !B) || (!A && B)' expression is equivalent to the 'bool(A) != bool(B)' expression.
libyaml/tests/run-emitter.c 154     warn    V728 An excessive check can be simplified. The '(A && !B) || (!A && B)' expression is equivalent to the 'bool(A) != bool(B)' expression.
libyaml/tests/run-emitter.c 166     warn    V728 An excessive check can be simplified. The '(A && !B) || (!A && B)' expression is equivalent to the 'bool(A) != bool(B)' expression.
libyaml/tests/run-emitter.c 172     warn    V728 An excessive check can be simplified. The '(A && !B) || (!A && B)' expression is equivalent to the 'bool(A) != bool(B)' expression.
libyaml/tests/run-dumper.c  133     warn    V728 An excessive check can be simplified. The '(A && !B) || (!A && B)' expression is equivalent to the 'bool(A) != bool(B)' expression.
