### PR TITLE
change dllexport controlling macro to use _WIN32 

### DIFF
--- a/include/yaml.h
+++ b/include/yaml.h
@@ -28,7 +28,7 @@ extern "C" {
 
 #if defined(__MINGW32__)
 #   define  YAML_DECLARE(type)  type
-#elif defined(WIN32)
+#elif defined(_WIN32)
 #   if defined(YAML_DECLARE_STATIC)
 #       define  YAML_DECLARE(type)  type
 #   elif defined(YAML_DECLARE_EXPORT)


### PR DESCRIPTION
use _WIN32 which is provided by msvc compiler, instead of WIN32 which is user configurable, and omitted by default on some x64 builds.

I'm still needing to do:
#define YAML_DECLARE_STATIC
#include <yaml.h>
in my own code on windows builds to avoid dllimport when using libyaml as a static library, but this is acceptable.
