### PR TITLE
Forbid escaped singlequote in doublequotes

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -3166,10 +3166,6 @@ yaml_parser_scan_flow_scalar(yaml_parser_t *parser, yaml_token_t *token,
                         *(string.pointer++) = '/';
                         break;
 
-                    case '\'':
-                        *(string.pointer++) = '\'';
-                        break;
-
                     case '\\':
                         *(string.pointer++) = '\\';
                         break;


### PR DESCRIPTION
See also issue #68

I did not write a test for it because I don't know yet how to do that.
But there is a test for it in yaml-test-suite.
Unfortunately there's no script for testing invalid YAML test cases,
~and there's also another issue #73~

