### PR TITLE
Undefined PTRDIFF_MAX on HP-UX

### DIFF
--- a/src/yaml_private.h
+++ b/src/yaml_private.h
@@ -10,6 +10,13 @@
 
 #ifndef _MSC_VER
 #include <stdint.h>
+#ifndef PTRDIFF_MAX /* gcc on HP-UX sucks */
+#ifdef _LP64
+#define PTRDIFF_MAX 0x7FFFFFFFFFFFFFFFLL
+#else
+#define PTRDIFF_MAX 0x7FFFFFFFL
+#endif
+#endif
 #else
 #ifdef _WIN64
 #define PTRDIFF_MAX _I64_MAX


### PR DESCRIPTION
@Tux reported this on IRC:
```
reader.c: In function 'yaml_parser_update_buffer':
reader.c:463:27: error: 'PTRDIFF_MAX' undeclared (first use in this function)
reader.c:463:27: note: each undeclared identifier is reported only once for each function it appears in

HP-UX 11.23 ia64 5.24.1/64all/longdouble/gcc-4.6.0
```