### PR TITLE
Rename config.h to yaml_config.h to prevent naming conflicts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ set(SRCS
   src/writer.c
   )
 
-set(config_h ${CMAKE_CURRENT_BINARY_DIR}/include/config.h)
+set(config_h ${CMAKE_CURRENT_BINARY_DIR}/include/yaml_config.h)
 configure_file(
   cmake/config.h.in
   ${config_h}

--- a/configure.ac
+++ b/configure.ac
@@ -26,7 +26,7 @@ m4_define([YAML_AGE], 0)
 AC_PREREQ(2.59)
 AC_INIT([yaml], [YAML_MAJOR.YAML_MINOR.YAML_PATCH], [YAML_BUGS])
 AC_CONFIG_AUX_DIR([config])
-AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_HEADERS([yaml_config.h])
 AM_INIT_AUTOMAKE([1.9 foreign])
 
 # Define macro variables for the package version numbers.

--- a/src/yaml_private.h
+++ b/src/yaml_private.h
@@ -1,5 +1,5 @@
 #if HAVE_CONFIG_H
-#include <config.h>
+#include <yaml_config.h>
 #endif
 
 #include <yaml.h>


### PR DESCRIPTION
libyaml was installing config.h into $INCLUDE_DIR/config.h (eg /usr/include/config.h), which has a high potential of causing naming conflicts. So I renamed the output file to yaml_config.h. This is working with the cmake build system; automake has not yet been tested.