### PR TITLE
add -no-undefined to src/Makefile.am

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
 AM_CPPFLAGS = -I$(top_srcdir)/include -Wall
 lib_LTLIBRARIES = libyaml.la
 libyaml_la_SOURCES = yaml_private.h api.c reader.c scanner.c parser.c loader.c writer.c emitter.c dumper.c
-libyaml_la_LDFLAGS = -release $(YAML_LT_RELEASE) -version-info $(YAML_LT_CURRENT):$(YAML_LT_REVISION):$(YAML_LT_AGE)
+libyaml_la_LDFLAGS = -no-undefined -release $(YAML_LT_RELEASE) -version-info $(YAML_LT_CURRENT):$(YAML_LT_REVISION):$(YAML_LT_AGE)


### PR DESCRIPTION
Without this change building a dll with the mingw-w64 toolchain is
impossible. All tests from make test-all succeed on native linux
(Gentoo amd64 glibc default/linux/amd64/17.1/desktop gcc-7.2.0)

Signed-off-by: Marty E. Plummer <hanetzer@protonmail.com>