### PR TITLE
appveyor.yml: add mingw-w64 builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,15 @@
 .deps/
 .libs/
-*~
 *.BAK
+*.a
+*.dll
+*.exe
 *.la
 *.lo
 *.o
 *.pc
+*.so
+*~
 /CMakeCache.txt
 /CMakeFiles/
 /CTestTestfile.cmake

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,11 @@ build_script:
 # Autoconf based in-source build and tests under Cygwin using gcc
 #
 
-# 32-bit
+# 32-bit cygwin build
 - C:\cygwin\bin\sh -c "export PATH=/usr/bin:/usr/local/bin:$PATH && ./bootstrap && ./configure && make && make test && make distclean"
-# 64-bit
+# 64-bit cygwin build
 - C:\cygwin64\bin\sh -c "export PATH=/usr/bin:/usr/local/bin:$PATH && ./bootstrap && ./configure && make && make test && make distclean"
+# 32-bit mingw-w64 build
+- C:\cygwin\bin\sh -c "export PATH=/usr/bin:/usr/local/bin:$PATH && ./bootstrap && ./configure --host=i686-w64-mingw32 --target=i686-w64-mingw32 && make && make test && make distclean"
+# 64-bit mingw-w64 build
+- C:\cygwin64\bin\sh -c "export PATH=/usr/bin:/usr/local/bin:$PATH && ./bootstrap && ./configure --host=x86_64-w64-mingw32 --target=x86_64-w64-mingw32 && make && make test && make distclean"


### PR DESCRIPTION
Currently the cygwin autoconf builds only test builds of cygwin-native
binaries, and not mingw-w64 pure windows binaries. The resultant
cygyaml-0-2.dll has a runtime dep on the cygwin1.dll which is generally
not appropriate for the purpose of distribution. Building with mingw-w64
produces libraries with no dependency on the cygwin runtime.

Signed-off-by: Marty E. Plummer <hanetzer@protonmail.com>