### PR TITLE
Release YAML 0.1.8.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2006-2016 Kirill Simonov
+Copyright (c) 2006-2018 Kirill Simonov and the libyaml contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
It's been over a year since libyaml was released. The mew maintainers have not
yet cut a release. There has been a bunch of work done.

This PR and branch will be used to prepare the release.

We need to make a release checklist. I'm not sure all that is involved in a
release.

There are a number of PRs that probably belong in the release:

- #84 Rename config.h to yaml_config.h to prevent naming conflicts
- #83 Fixed most compiler warnings -Wall -Wextra (based on #27)
- #28 colon can be in a plain scalar (waiting on @flyx review/assessment)
- #6 Use pointer to const for strings that aren't/shouldn't be modified
- #66 change dllexport controlling macro to use _WIN32 (need @hanetzer review)
- #64 README: Update libyaml link
- #19 Patch to guard against integer overflow (needs review)
- #16 Add Solaris compilation fix from Perl binding repo

Any ideas to make the repo layout better before we release would be
appreciated.

We do need to wait until @flyx returns (a week more I think) so gives us time.

