### PR TITLE
build: do not install config.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,6 @@ target_include_directories(yaml PUBLIC
 install(
   FILES
     include/yaml.h
-    ${config_h}
   DESTINATION include COMPONENT Development
   )
 

--- a/configure.ac
+++ b/configure.ac
@@ -26,7 +26,7 @@ m4_define([YAML_AGE], 0)
 AC_PREREQ(2.59)
 AC_INIT([yaml], [YAML_MAJOR.YAML_MINOR.YAML_PATCH], [YAML_BUGS])
 AC_CONFIG_AUX_DIR([config])
-AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_HEADERS([include/config.h])
 AM_INIT_AUTOMAKE([1.9 foreign])
 
 # Define macro variables for the package version numbers.

--- a/src/yaml_private.h
+++ b/src/yaml_private.h
@@ -1,5 +1,5 @@
 #if HAVE_CONFIG_H
-#include <config.h>
+#include "config.h"
 #endif
 
 #include <yaml.h>


### PR DESCRIPTION
'config.h' is meant to be a convenience header to be #included at build
time, but not installed. Installing it can cause a host of problems for
various other projects (for instance, attempting to build u-boot from
source while another project's 'config.h' exists in the compiler search
path will cause build failures similar to: https://github.com/pepe2k/u-boot_mod/issues/148

Further, I've changed `#include <config.h>` to `#include "config.h"`,
which should constrain the search path to the current build directories,
so if another package with a bugged build has this file installed, it
will not cause yaml to miscompile/fail.

If you have a file `/usr/include/config.h` on your filesystem, query
your package manager to find out what package owns it, and file a bug
report against it with your distro maintainers.

Signed-off-by: Marty E. Plummer <hanetzer@protonmail.com>
  