### PR TITLE
appveyor.yml: fix Release build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,8 @@ build_script:
 
 # Use 32-bit default generator ("Visual Studio 12 2013" or "Visual Studio 14 2015")
 - cmake .
-- cmake --build . --config release --clean-first
-- ctest -C release
+- cmake --build . --config Release --clean-first
+- ctest -C Release
 
 #
 # Autoconf based in-source build and tests under Cygwin using gcc


### PR DESCRIPTION
I suspect this this was a bit of an oversight when first setting up
appveyor for Windows/msvc, but 'release' does not match any target
cmake knows about; 'Release', however, does.

Signed-off-by: Marty E. Plummer <hanetzer@protonmail.com>