### PR TITLE
Remove unused code in yaml_document_delete

### DIFF
--- a/include/yaml.h
+++ b/include/yaml.h
@@ -97,7 +97,7 @@ typedef struct yaml_tag_directive_s {
 
 /** The stream encoding. */
 typedef enum yaml_encoding_e {
-    /** Let the parser choose the encoding. */
+    /** Let the parser choose the encoding. The initial state, invalid at runtime. */
     YAML_ANY_ENCODING,
     /** The default UTF-8 encoding. */
     YAML_UTF8_ENCODING,

--- a/src/api.c
+++ b/src/api.c
@@ -1117,12 +1117,7 @@ error:
 YAML_DECLARE(void)
 yaml_document_delete(yaml_document_t *document)
 {
-    struct {
-        yaml_error_type_t error;
-    } context;
     yaml_tag_directive_t *tag_directive;
-
-    context.error = YAML_NO_ERROR;  /* Eliminate a compliler warning. */
 
     assert(document);   /* Non-NULL document object is expected. */
 


### PR DESCRIPTION
Eliminates a compiler warning.

This is another chery-pick from @rurban's PR #27
