### PR TITLE
Allow question marks in plain scalars in flow collections

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -3457,7 +3457,7 @@ yaml_parser_scan_plain_scalar(yaml_parser_t *parser, yaml_token_t *token)
             if ((CHECK(parser->buffer, ':') && IS_BLANKZ_AT(parser->buffer, 1))
                     || (parser->flow_level &&
                         (CHECK(parser->buffer, ',')
-                         || CHECK(parser->buffer, '?') || CHECK(parser->buffer, '[')
+                         || CHECK(parser->buffer, '[')
                          || CHECK(parser->buffer, ']') || CHECK(parser->buffer, '{')
                          || CHECK(parser->buffer, '}'))))
                 break;


### PR DESCRIPTION
See http://yaml.org/spec/1.1/#id907281

The question mark isn't mentioned as something special here, only
`,[]{}`

This commit will allow

    [foo?bar]
    [foo ? bar]

The PR does only change the behaviour when the question mark is in the middle or at the end of the string, not at the beginning, e.g. `[?foo]` is handled by a different part of the code.

