### PR TITLE
Fixed return value of yaml_parser_scan

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -751,7 +751,7 @@ yaml_parser_scan(yaml_parser_t *parser, yaml_token_t *token)
     /* No tokens after STREAM-END or error. */
 
     if (parser->stream_end_produced || parser->error) {
-        return 1;
+        return 0;
     }
 
     /* Ensure that the tokens queue contains enough tokens. */


### PR DESCRIPTION
yaml_parser_scan should return 0 while stream end or parser error.