### PR TITLE
The closing single quote needs to be indented...

### DIFF
--- a/src/emitter.c
+++ b/src/emitter.c
@@ -2004,6 +2004,9 @@ yaml_emitter_write_single_quoted_scalar(yaml_emitter_t *emitter,
         }
     }
 
+    if (breaks)
+        if (!yaml_emitter_write_indent(emitter)) return 0;
+
     if (!yaml_emitter_write_indicator(emitter, "'", 0, 0, 0))
         return 0;
 


### PR DESCRIPTION
if it's on its own line.

Current output:

```
% cd libyaml
% echo "+STR
+DOC
+SEQ
=VAL '\\\n
-SEQ
-DOC
-STR" | ./tests/run-emitter-test-suite
- '

'
```

With this patch:

```
% echo "+STR
+DOC
+SEQ
=VAL '\\\n
-SEQ
-DOC
-STR" | ./tests/run-emitter-test-suite
- '

  '
```

Test suite suceeds.

The same rule would apply to double quoted strings, but I haven't been
able to produce a case where the closing double quote was on its own line.

