### PR TITLE
Revert removing of open_ended after top level plain scalar

### DIFF
--- a/src/emitter.c
+++ b/src/emitter.c
@@ -1946,6 +1946,10 @@ yaml_emitter_write_plain_scalar(yaml_emitter_t *emitter,
 
     emitter->whitespace = 0;
     emitter->indention = 0;
+    if (emitter->root_context)
+    {
+        emitter->open_ended = 1;
+    }
 
     return 1;
 }

--- a/src/emitter.c
+++ b/src/emitter.c
@@ -649,13 +649,6 @@ yaml_emitter_emit_document_start(yaml_emitter_t *emitter,
 
     else if (event->type == YAML_STREAM_END_EVENT)
     {
-        if (emitter->open_ended)
-        {
-            if (!yaml_emitter_write_indicator(emitter, "...", 1, 0, 0))
-                return 0;
-            if (!yaml_emitter_write_indent(emitter))
-                return 0;
-        }
 
         if (!yaml_emitter_flush(emitter))
             return 0;


### PR DESCRIPTION
See also issue #60

This reverts commit 56400d976a1999156b1abfd674c3122843980260.

Currently tests will fail because we have the yaml-test-suite with very strict
tests that check for explicit document start/end markers.

So the following tests need to be skipped for now: `27NA 35KP 4V8U 9KAX P76L`

The problematic case was that it created the following YAML:
```
--- foo
%YAML 1.1
--- bar
```
But you would need `...` after `foo' here. Only when quoted you can leave out the end marker:
```
--- "foo"
%YAML 1.1
--- bar
```

In YAML 1.2 you always have to add the end marker, so I think it's a good thing.

But I know that the end marker also gets added to cases where it is *not* needed. Maybe I can have a look into that.