### PR TITLE
Squash a couple of warnings in example-deconstructor-alt

### DIFF
--- a/tests/example-deconstructor-alt.c
+++ b/tests/example-deconstructor-alt.c
@@ -635,10 +635,10 @@ main(int argc, char *argv[])
 
                 /* Display the style information. */
 
-                if (input_event.data.sequence_start.style)
+                if (input_event.data.mapping_start.style)
                 {
-                    yaml_sequence_style_t style
-                        = (yaml_sequence_style_t) input_event.data.mapping_start.style;
+                    yaml_mapping_style_t style
+                        = input_event.data.mapping_start.style;
 
                     /* Add 'style': <style>. */
 


### PR DESCRIPTION
example-deconstructor-alt.c: In function ‘main’:
example-deconstructor-alt.c:649:51: warning:
  comparison between ‘yaml_sequence_style_t {aka enum yaml_sequence_style_e}’
  and ‘enum yaml_mapping_style_e’ [-Wenum-compare]

example-deconstructor-alt.c:650:36: warning:
  comparison between ‘yaml_sequence_style_t {aka enum yaml_sequence_style_e}’
  and ‘enum yaml_mapping_style_e’ [-Wenum-compare]