### PR TITLE
Fixed typo.

### DIFF
--- a/src/emitter.c
+++ b/src/emitter.c
@@ -1227,7 +1227,7 @@ yaml_emitter_select_scalar_style(yaml_emitter_t *emitter, yaml_event_t *event)
 }
 
 /*
- * Write an achor.
+ * Write an anchor.
  */
 
 static int

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -3518,7 +3518,7 @@ yaml_parser_scan_plain_scalar(yaml_parser_t *parser, yaml_token_t *token)
         {
             if (IS_BLANK(parser->buffer))
             {
-                /* Check for tab character that abuse indentation. */
+                /* Check for tab characters that abuse indentation. */
 
                 if (leading_blanks && (int)parser->mark.column < indent
                         && IS_TAB(parser->buffer)) {


### PR DESCRIPTION
Hi, I picked typofix from psych changes(as known as yaml wrapper of the ruby language)

see https://github.com/ruby/psych/pull/368/commits/d4f1d4b4106bacac18110884dc2e860eeb58634f