### PR TITLE
Emit codepoints U+80-U+9F correctly

### DIFF
--- a/src/emitter.c
+++ b/src/emitter.c
@@ -2116,8 +2116,13 @@ yaml_emitter_write_double_quoted_scalar(yaml_emitter_t *emitter,
                     break;
 
                 default:
-                    if (value <= 0xFF) {
+                    if (value <= 0x7F) {
                         if (!PUT(emitter, 'x')) return 0;
+                        width = 2;
+                    } else if (value <= 0xFF) {
+                        if (!PUT(emitter, 'u')) return 0;
+                        if (!PUT(emitter, '0')) return 0;
+                        if (!PUT(emitter, '0')) return 0;
                         width = 2;
                     }
                     else if (value <= 0xFFFF) {


### PR DESCRIPTION
The emitter currently generates codepoints `U+80`-`U+9F` as (e.g.) `"\x80".` This is technically incorrect for UTF-8:

With UTF-8, if the high bit is set (as it is in `0x80` = `1000 0000`), it indicates this byte is part of a multibyte character. That means everything over `0x7F` has to be represented in multibyte, according to the [UTF-8 RFC](https://tools.ietf.org/html/rfc3629#section-3).

You can see here that `0x7F`-`0xFF` should be spread over the 'x' bits in:

    110xxxxx 10xxxxxx

So, for example, `0x92` should be:

    0xc2     0x92
    11000010 10010010

A byte starting with `0b10` is unambiguously a "continuatuion" byte, meaning that it only has meaning if part of a multibyte sequence.

Because `0x80`-`0xBF` fall into this range, they are *sort of* parseable. They're technically invalid, but couldn't mean anything other than `U+80`-`U+BF` because they don't follow a multibyte start byte.

However, while libyaml itself is able to correctly roundtrip documents containing these bytes, we have had issues trying to interact with them via other tools.

This problem only affects `U+80`-`U+9F`, as `U+A0`-`U+FF` are embedded literally in the document.
