### PR TITLE
Windows/C89 compatibility

### DIFF
--- a/tests/run-dumper.c
+++ b/tests/run-dumper.c
@@ -79,10 +79,12 @@ error:
 int compare_nodes(yaml_document_t *document1, int index1,
         yaml_document_t *document2, int index2, int level)
 {
-    if (level++ > 1000) return 0;
-    yaml_node_t *node1 = yaml_document_get_node(document1, index1);
-    yaml_node_t *node2 = yaml_document_get_node(document2, index2);
     int k;
+    yaml_node_t *node1;
+    yaml_node_t *node2;
+    if (level++ > 1000) return 0;
+    node1 = yaml_document_get_node(document1, index1);
+    node2 = yaml_document_get_node(document2, index2);
 
     assert(node1);
     assert(node2);

--- a/tests/run-emitter-test-suite.c
+++ b/tests/run-emitter-test-suite.c
@@ -2,10 +2,9 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <stdbool.h>
 #include <assert.h>
 
-bool get_line(FILE * input, char *line);
+int get_line(FILE * input, char *line);
 char *get_anchor(char sigil, char *line, char *anchor);
 char *get_tag(char *line, char *tag);
 void get_value(char *line, char *value, int *style);
@@ -134,12 +133,12 @@ int main(int argc, char *argv[])
     return 1;
 }
 
-bool get_line(FILE * input, char *line)
+int get_line(FILE * input, char *line)
 {
     char *newline;
 
     if (!fgets(line, 1024 - 1, input))
-        return false;
+        return 0;
 
     if ((newline = strchr(line, '\n')) == NULL) {
         fprintf(stderr, "Line too long: '%s'", line);
@@ -147,7 +146,7 @@ bool get_line(FILE * input, char *line)
     }
     *newline = '\0';
 
-    return true;
+    return 1;
 }
 
 char *get_anchor(char sigil, char *line, char *anchor)


### PR DESCRIPTION
We had some problems building PyYAML together with libyaml on appveyor Windows
(Microsoft Visual Studio 10.0)

Problem 1:
```
"C:\projects\pyyaml\libyaml\build\ALL_BUILD.vcxproj" (default target) (1) ->
"C:\projects\pyyaml\libyaml\build\tests\run-dumper.vcxproj" (default target) (8) ->
(ClCompile target) ->
  ..\..\tests\run-dumper.c(83): error C2275: 'yaml_node_t' : illegal use of this type as an expression [C:\projects\pyyaml\libyaml\build\tests\run-dumper.vcxproj]
  ..\..\tests\run-dumper.c(83): error C2065: 'node1' : undeclared identifier [C:\projects\pyyaml\libyaml\build\tests\run-dumper.vcxproj]
```
Because a declaration comes after code.

Problem 2:
```
"C:\projects\pyyaml\libyaml\build\ALL_BUILD.vcxproj" (default target) (1) ->
"C:\projects\pyyaml\libyaml\build\tests\run-emitter-test-suite.vcxproj" (default target) (10) ->
  ..\..\tests\run-emitter-test-suite.c(5): fatal error C1083: Cannot open include file: 'stdbool.h': No such file or directory [C:\projects\pyyaml\libyaml\build\tests\run-emitter-test-suite.vcxproj]
```
So stdbool.h is not available.

This PR fixes both.

