### PR TITLE
allow override of Windows static lib name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set (YAML_VERSION_PATCH 7)
 set (YAML_VERSION_STRING "${YAML_VERSION_MAJOR}.${YAML_VERSION_MINOR}.${YAML_VERSION_PATCH}")
 
 option(BUILD_SHARED_LIBS "Build libyaml as a shared library" OFF)
+option(YAML_STATIC_LIB_NAME "base name of static library output" yaml)
 
 #
 # Output directories for a build tree
@@ -56,8 +57,8 @@ add_library(yaml ${SRCS})
 
 if(NOT BUILD_SHARED_LIBS)
   set_target_properties(yaml
-    PROPERTIES OUTPUT_NAME yaml_static
-    )
+    PROPERTIES OUTPUT_NAME ${YAML_STATIC_LIB_NAME}
+  )
 endif()
 
 set_target_properties(yaml


### PR DESCRIPTION
* previous change to `yaml_static.lib` in #10 breaks things that expect `yaml.lib`; change it back, but allow an override via `-DYAML_STATIC_LIB_NAME=whatever` when generating makefiles.