### PR TITLE
Fix spelling for error message

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -3523,7 +3523,7 @@ yaml_parser_scan_plain_scalar(yaml_parser_t *parser, yaml_token_t *token)
                 if (leading_blanks && (int)parser->mark.column < indent
                         && IS_TAB(parser->buffer)) {
                     yaml_parser_set_scanner_error(parser, "while scanning a plain scalar",
-                            start_mark, "found a tab character that violate indentation");
+                            start_mark, "found a tab character that violates indentation");
                     goto error;
                 }
 


### PR DESCRIPTION
**Proposed change:**
Change violate to violates.

**Reference:**
I came here from finding a issue with the error message as used in ansible-playbook --syntax-check: https://github.com/ansible/ansible/issues/59547