### PR TITLE
Free version_directive if not stored for later use

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -1301,6 +1301,9 @@ yaml_parser_process_directives(yaml_parser_t *parser,
 
     if (version_directive_ref) {
         *version_directive_ref = version_directive;
+    else {
+        yaml_free(version_directive);
+        version_directive = NULL;
     }
     if (tag_directives_start_ref) {
         if (STACK_EMPTY(parser, tag_directives)) {


### PR DESCRIPTION
This was an error returned from Coverity static analysis tool:

Error: RESOURCE_LEAK (CWE-772):

yaml-0.1.7/src/parser.c:1273: alloc_fn: Storage is returned from allocation function "yaml_malloc".
yaml-0.1.7/src/api.c:33:5: alloc_fn: Storage is returned from allocation function "malloc".
yaml-0.1.7/src/api.c:33:5: return_alloc_fn: Directly returning storage allocated by "malloc".
yaml-0.1.7/src/parser.c:1273: var_assign: Assigning: "version_directive" = storage returned from "yaml_malloc(8UL)".
yaml-0.1.7/src/parser.c:1323: leaked_storage: Variable "version_directive" going out of scope leaks the storage it points to.
  1321|       }
  1322|
  1323|->     return 1;
  1324|
  1325|   error:

Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=1602610

Credits to @kdudka, who originally suggested this patch in the bz above.