### PR TITLE
Always output document end before directive (YAML 1.2 compatibility)

### DIFF
--- a/src/emitter.c
+++ b/src/emitter.c
@@ -594,6 +594,7 @@ yaml_emitter_emit_document_start(yaml_emitter_t *emitter,
         {
             if (!yaml_emitter_write_indicator(emitter, "...", 1, 0, 0))
                 return 0;
+            emitter->open_ended = 0;
             if (!yaml_emitter_write_indent(emitter))
                 return 0;
         }
@@ -644,6 +645,7 @@ yaml_emitter_emit_document_start(yaml_emitter_t *emitter,
 
         emitter->state = YAML_EMIT_DOCUMENT_CONTENT_STATE;
 
+        emitter->open_ended = 0;
         return 1;
     }
 
@@ -691,6 +693,7 @@ yaml_emitter_emit_document_end(yaml_emitter_t *emitter,
         if (!event->data.document_end.implicit) {
             if (!yaml_emitter_write_indicator(emitter, "...", 1, 0, 0))
                 return 0;
+            emitter->open_ended = 0;
             if (!yaml_emitter_write_indent(emitter))
                 return 0;
         }
@@ -1796,7 +1799,6 @@ yaml_emitter_write_indicator(yaml_emitter_t *emitter,
 
     emitter->whitespace = is_whitespace;
     emitter->indention = (emitter->indention && is_indention);
-    emitter->open_ended = 0;
 
     return 1;
 }
@@ -1939,10 +1941,6 @@ yaml_emitter_write_plain_scalar(yaml_emitter_t *emitter,
 
     emitter->whitespace = 0;
     emitter->indention = 0;
-    if (emitter->root_context)
-    {
-        emitter->open_ended = 1;
-    }
 
     return 1;
 }


### PR DESCRIPTION
In YAML 1.1, the document end marker `...` is optional even if the next document starts with a directive:
https://github.com/yaml/pyyaml/blob/master/tests/data/spec-07-09.canonical
```
%YAML 1.1
---
!!str "foo"
%YAML 1.1
---
!!str "bar"
%YAML 1.1
---
!!str "baz"
```
It is only required if the scalar is "open ended", for example for plain scalars.

My suggestion would be to make the output 1.2 compatible. It will still be 1.1 compatible, so that shouldn't be a problem.

In YAML 1.2 the `...` marker is always required before a directive. So the new output looks like:
```
%YAML 1.1
---
!!str "foo"
...
%YAML 1.1
---
!!str "bar"
...
%YAML 1.1
---
!!str "baz"
```

I believe this will also make it easier to resolve `#123` (no github, this will *not* fix 123) which was introduced with the last fixes regarding `open_ended`. I think I can make a fix for this soon after this issue is fixed.
Fixing #123 without this would be a bit more complicated.

If we do this, we also need to adjust PyYAML to behave the same.

Related issues/commits:
- https://github.com/yaml/libyaml/issues/60
- https://github.com/yaml/libyaml/pull/122
- 56400d9, 8ee83c0, 56f4b17
