### PR TITLE
WIP Output document end marker after open ended scalars

### DIFF
--- a/src/emitter.c
+++ b/src/emitter.c
@@ -652,6 +652,18 @@ yaml_emitter_emit_document_start(yaml_emitter_t *emitter,
     else if (event->type == YAML_STREAM_END_EVENT)
     {
 
+        /**
+         * This can happen if a block scalar with trailing empty lines
+         * is at the end of the stream
+         */
+        if (emitter->open_ended)
+        {
+            if (!yaml_emitter_write_indicator(emitter, "...", 1, 0, 0))
+                return 0;
+            emitter->open_ended = 0;
+            if (!yaml_emitter_write_indent(emitter))
+                return 0;
+        }
         if (!yaml_emitter_flush(emitter))
             return 0;
 


### PR DESCRIPTION
See also #123

Depends on: #160 

This will output `...` at the end of the YAML Stream if the previous scalar is open ended, e.g. a block scalar `|+` with trailing empty lines.

Tests passing:
blacklist/libyaml-emitter 
* F8F9: Spec Example 8.5. Chomping Trailing Lines
* K858: Spec Example 8.6. Empty Scalar Chomping