### PR TITLE
Fixed missing token in example

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -348,6 +348,7 @@
  *          SCALAR("another value",plain)
  *          KEY
  *          SCALAR("a mapping",plain)
+ *          VALUE
  *          BLOCK-MAPPING-START
  *          KEY
  *          SCALAR("key 1",plain)


### PR DESCRIPTION
Fixed missing VALUE token in an example provided for token generation in Block mappings.
