### PR TITLE
Allow dots and slashes in anchor names

### DIFF
--- a/src/emitter.c
+++ b/src/emitter.c
@@ -1421,7 +1421,11 @@ yaml_emitter_analyze_anchor(yaml_emitter_t *emitter,
     }
 
     while (string.pointer != string.end) {
-        if (!IS_ALPHA(string)) {
+        if (
+            !IS_ALPHA(string)
+            && !CHECK(string, '.')
+            && !CHECK(string, '/')
+        ) {
             return yaml_emitter_set_emitter_error(emitter, alias ?
                     "alias value must contain alphanumerical characters only" :
                     "anchor value must contain alphanumerical characters only");

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -2336,7 +2336,11 @@ yaml_parser_scan_anchor(yaml_parser_t *parser, yaml_token_t *token,
 
     if (!CACHE(parser, 1)) goto error;
 
-    while (IS_ALPHA(parser->buffer)) {
+    while (
+        IS_ALPHA(parser->buffer)
+        || CHECK(parser->buffer, '.')
+        || CHECK(parser->buffer, '/')
+    ) {
         if (!READ(parser, string)) goto error;
         if (!CACHE(parser, 1)) goto error;
         length ++;


### PR DESCRIPTION
The same change is planned for PyYAML: https://github.com/yaml/pyyaml/pull/389

With this change the allowed characters for aliases/anchors are: `A-Z a-z 0-9 _ - . /`

The spec allows more characters than that, but it's currently not planned to allow all of them in libyaml.

There is no specific test for that in yaml-test-suite, but a pull request exists:
https://github.com/yaml/yaml-test-suite/pull/54