### PR TITLE
Support %YAML 1.2 directives

### DIFF
--- a/src/emitter.c
+++ b/src/emitter.c
@@ -1341,7 +1341,10 @@ static int
 yaml_emitter_analyze_version_directive(yaml_emitter_t *emitter,
         yaml_version_directive_t version_directive)
 {
-    if (version_directive.major != 1 || version_directive.minor != 1) {
+    if (version_directive.major != 1 || (
+        version_directive.minor != 1
+        && version_directive.minor != 2
+        )) {
         return yaml_emitter_set_emitter_error(emitter,
                 "incompatible %YAML directive");
     }

--- a/src/parser.c
+++ b/src/parser.c
@@ -1261,7 +1261,10 @@ yaml_parser_process_directives(yaml_parser_t *parser,
                 goto error;
             }
             if (token->data.version_directive.major != 1
-                    || token->data.version_directive.minor != 1) {
+                    || (
+                        token->data.version_directive.minor != 1
+                        && token->data.version_directive.minor != 2
+                    )) {
                 yaml_parser_set_parser_error(parser,
                         "found incompatible YAML document", token->start_mark);
                 goto error;


### PR DESCRIPTION
This will allow `%YAML 1.2` directives.

See also #20

No changes are needed regarding tag directives.

In YAML 1.2 tag directives are for the following document only.
This is already implemented like that in libyaml.

We would rather have to fix the code if we want to have the correct behaviour
(global directives) in YAML 1.1. This would be a bit more complicated, as we
would have to save the default version and the current version in the parser
object.

New passing parser tests:

* 27NA: Spec Example 5.9. Directive Indicator
* 6ZKB: Spec Example 9.6. Stream
* 9DXL: Spec Example 9.6. Stream [1.3]
* RTP8: Spec Example 9.2. Document Markers

New failing error parser tests (before they were errors for the wrong reason):

* EB22: Missing document-end marker before directive
* RHX7: YAML directive without document end marker

Tests are currectly failing because I cannot edit the skiplist from this PR.
Not sure why travis doesn't show up here:
https://travis-ci.org/github/yaml/libyaml/builds/668849280