### PR TITLE
Fix logic for document end before directive

### DIFF
--- a/src/emitter.c
+++ b/src/emitter.c
@@ -603,8 +603,14 @@ yaml_emitter_emit_document_start(yaml_emitter_t *emitter,
             implicit = 0;
             if (!yaml_emitter_write_indicator(emitter, "%YAML", 1, 0, 0))
                 return 0;
-            if (!yaml_emitter_write_indicator(emitter, "1.1", 1, 0, 0))
-                return 0;
+            if (event->data.document_start.version_directive->minor == 1) {
+                if (!yaml_emitter_write_indicator(emitter, "1.1", 1, 0, 0))
+                    return 0;
+            }
+            else {
+                if (!yaml_emitter_write_indicator(emitter, "1.2", 1, 0, 0))
+                    return 0;
+            }
             if (!yaml_emitter_write_indent(emitter))
                 return 0;
         }

--- a/src/emitter.c
+++ b/src/emitter.c
@@ -495,6 +495,7 @@ static int
 yaml_emitter_emit_stream_start(yaml_emitter_t *emitter,
         yaml_event_t *event)
 {
+    emitter->open_ended = 0;
     if (event->type == YAML_STREAM_START_EVENT)
     {
         if (!emitter->encoding) {
@@ -594,10 +595,10 @@ yaml_emitter_emit_document_start(yaml_emitter_t *emitter,
         {
             if (!yaml_emitter_write_indicator(emitter, "...", 1, 0, 0))
                 return 0;
-            emitter->open_ended = 0;
             if (!yaml_emitter_write_indent(emitter))
                 return 0;
         }
+        emitter->open_ended = 0;
 
         if (event->data.document_start.version_directive) {
             implicit = 0;
@@ -662,7 +663,7 @@ yaml_emitter_emit_document_start(yaml_emitter_t *emitter,
          * This can happen if a block scalar with trailing empty lines
          * is at the end of the stream
          */
-        if (emitter->open_ended)
+        if (emitter->open_ended == 2)
         {
             if (!yaml_emitter_write_indicator(emitter, "...", 1, 0, 0))
                 return 0;
@@ -715,6 +716,8 @@ yaml_emitter_emit_document_end(yaml_emitter_t *emitter,
             if (!yaml_emitter_write_indent(emitter))
                 return 0;
         }
+        else if (!emitter->open_ended)
+            emitter->open_ended = 1;
         if (!yaml_emitter_flush(emitter))
             return 0;
 
@@ -2222,7 +2225,7 @@ yaml_emitter_write_block_scalar_hints(yaml_emitter_t *emitter,
         else if (string.start == string.pointer)
         {
             chomp_hint = "+";
-            emitter->open_ended = 1;
+            emitter->open_ended = 2;
         }
         else
         {
@@ -2232,7 +2235,7 @@ yaml_emitter_write_block_scalar_hints(yaml_emitter_t *emitter,
             if (IS_BREAK(string))
             {
                 chomp_hint = "+";
-                emitter->open_ended = 1;
+                emitter->open_ended = 2;
             }
         }
     }


### PR DESCRIPTION
See https://github.com/yaml/pyyaml/issues/396


open_ended can have three states now:
```
0: The previous document was ended explicitly with '...'
1: The previous document wasn't ended with '...'
2: The last scalar event was a block scalar with trailing empty lines |+, and
       last document wasn't ended with '...'.
       Important at stream end.
```

This was broken in the past, and fixed in fa1293a11f2137709aec313f5789502406e587dd.
With my last PR #162 I added the faulty behaviour again.

The problematic behaviour showed only when
* Writing YAML directives
* writing unquoted top level scalars
* writing more than one document

See the commit message for the second commit for examples how to show the behaviour.
Check out the commit before the fix and running the first example.

Additionally this PR contains:
* Allow writing `%YAML 1.2` directive. Before it was valid to pass `1.2` but the output was hardcoded to `1.1`
* Add `--directive (1.1|1.2)` to `./tests/run-emitter-test-suite` for easy debugging