### PR TITLE
Emitter: Don't output trailing space for empty scalar nodes

### DIFF
--- a/src/emitter.c
+++ b/src/emitter.c
@@ -1923,7 +1923,17 @@ yaml_emitter_write_plain_scalar(yaml_emitter_t *emitter,
 
     STRING_ASSIGN(string, value, length);
 
-    if (!emitter->whitespace) {
+    /**
+     * Avoid trailing spaces for empty values in block mode.
+     * In flow mode, we still want the space to prevent ambiguous things
+     * like {a:}.
+     * Currently, the emitter forbids any plain empty scalar in flow mode
+     * (e.g. it outputs {a: ''} instead), so emitter->flow_level will
+     * never be true here.
+     * But if the emitter is ever changed to allow emitting empty values,
+     * the check for flow_level is already here.
+     */
+    if (!emitter->whitespace && (length || emitter->flow_level)) {
         if (!PUT(emitter, ' ')) return 0;
     }
 


### PR DESCRIPTION
See issue #46

Passing emitter tests:
* 2XXW: Spec Example 2.25. Unordered Sets
* 5WE3: Spec Example 8.17. Explicit Block Mapping Entries
* 6KGN: Anchor for empty node
* 6XDY: Two document start markers
* 7W2P: Block Mapping with Missing Values
* 8KB6: Multiline plain flow mapping key without value
* 9BXH: Multiline doublequoted flow mapping key without value
* C2DT: Spec Example 7.18. Flow Mapping Adjacent Values
* JTV5: Block Mapping with Multiline Scalars
* KK5P: Various combinations of explicit block mappings
* LE5A: Spec Example 7.24. Flow Nodes
* UT92: Spec Example 9.4. Explicit Documents
* W42U: Spec Example 8.15. Block Sequence Entry Types
* W4TN: Spec Example 9.5. Directives Documents
* ZWK4: Key with anchor after missing explicit mapping value