### PR TITLE
Add -h and --flow (on|off|keep) to run-*-test-suite

### DIFF
--- a/tests/ReadMe.md
+++ b/tests/ReadMe.md
@@ -1,0 +1,63 @@
+# Testing the Parser and Emitter
+
+There are several programs to test the parser and emitter.
+
+## Parser
+
+    echo 'foo: bar' | ./tests/run-parser-test-suite
+
+This will output the parsing events in yaml-test-suite format:
+
+    +STR
+    +DOC
+    +MAP
+    =VAL :foo
+    =VAL :bar
+    -MAP
+    -DOC
+    -STR
+
+For flow style events, you have to enable it with the `--flow` option:
+
+    echo '{ foo: bar }' | ./tests/run-parser-test-suite --flow keep
+
+    ...
+    +MAP {}
+    ...
+
+In the future, this will be the default.
+
+You can also explicitly disable this style with `--flow off`, or output
+flow style always, with `--flow on`.
+
+## Emitter
+
+run-emitter-test-suite takes yaml-test-suite event format and emits YAML.
+
+    ./tests/run-parser-test-suite ... | ./tests/run-emitter-test-suite
+
+## Options
+
+* `--directive (1.1|1.2)`
+
+  Prints a version directive before every document.
+
+* `--flow on`
+
+  Will emit the whole document in flow style.
+
+* `--flow off`
+
+  Will emit the whole document in block style.
+
+* `--flow keep`
+
+  Will emit block/flow style like in the original document.
+
+Example:
+```
+% echo 'foo: [bar, {x: y}]' |
+  ./tests/run-parser-test-suite --flow keep |
+  ./tests/run-emitter-test-suite --flow keep
+foo: [bar, {x: y}]
+```


### PR DESCRIPTION
Because the yaml-test-suite will soon add the `[]` and `{}` flow collection styles to the event output, we need to be able to deal with both formats. This way, when switching to the new format, we just need to add the `--flow` parameter to the call.

This also makes it easier to test my recent fixes in flow style mode.
    
With `--flow (keep|on)` run-parser-test-suite will output:

    +MAP {}
    +SEQ []

run-emitter-test-suite will then emit flow style collections if requested:

    echo 'foo: [bar, {x: y}]' | ./tests/run-parser-test-suite | ./tests/run-emitter-test-suite
    echo 'foo: [bar, {x: y}]' | ./tests/run-parser-test-suite \
        --flow keep | ./tests/run-emitter-test-suite --flow keep