### PR TITLE
A couple patches to improve test suite support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,9 @@ jobs:
     - name: Install software
       run: |
         if [[ '${{ matrix.os }}' == macOS-latest ]]; then
-          brew install automake coreutils
+          brew install automake bash coreutils make
+          echo ::add-path::/usr/local/opt/coreutils/libexec/gnubin
+          echo ::add-path::/usr/local/opt/make/libexec/gnubin
         fi
     - name: Fetch branches
       run: |

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,6 +5,8 @@ SUBDIRS = include src . tests
 
 EXTRA_DIST = Changes ReadMe.md License CMakeLists.txt doc/doxygen.cfg
 
+LIBYAML_TEST_SUITE_RUN_BRANCH ?= run-test-suite
+
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = yaml-0.1.pc
 
@@ -31,9 +33,9 @@ test-suite: tests/run-test-suite all
 test-all: test test-suite
 
 tests/run-test-suite:
-	-git branch --track run-test-suite origin/run-test-suite
+	-git branch --track $(LIBYAML_TEST_SUITE_RUN_BRANCH) origin/$(LIBYAML_TEST_SUITE_RUN_BRANCH)
 	-git worktree prune
-	git worktree add $@ run-test-suite
+	git worktree add $@ $(LIBYAML_TEST_SUITE_RUN_BRANCH)
 
 packaging:
 	-git branch --track $@ origin/$@


### PR DESCRIPTION
The GitHub Actions commit puts modern tools on Macos, and makes sure they can be called by their proper names.

The Makefile.am change allows the current run-test-suite branch to be changed.
This is useful for testing new branches.
