### PR TITLE
Add workflows for creating release tarballs and pyyaml testing

### DIFF
--- a/.github/workflows/dist.yaml
+++ b/.github/workflows/dist.yaml
@@ -1,0 +1,28 @@
+name: dist
+
+on:
+  push:
+    branches: [ release/* ]
+
+jobs:
+  dist:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - run: env | sort
+
+    - name: Get image
+      run: |
+        time docker pull yamlio/libyaml-dev
+        docker images | grep libyaml
+
+    - run: |
+        make -C pkg/docker libyaml-dist-ci
+        ls -l pkg/docker/output
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: release
+        path: pkg/docker/output/yaml-0*
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,8 @@ jobs:
 
   build:
 
+    env:
+      CC: ${{ matrix.compiler }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -25,12 +27,11 @@ jobs:
 
     - run: env | sort
     - name: Install software
+      if: ${{ matrix.os == 'macOS-latest' }}
       run: |
-        if [[ '${{ matrix.os }}' == macOS-latest ]]; then
-          brew install automake bash coreutils make
-          echo ::add-path::/usr/local/opt/coreutils/libexec/gnubin
-          echo ::add-path::/usr/local/opt/make/libexec/gnubin
-        fi
+        brew install automake bash coreutils make
+        echo ::add-path::/usr/local/opt/coreutils/libexec/gnubin
+        echo ::add-path::/usr/local/opt/make/libexec/gnubin
     - name: Fetch branches
       run: |
         git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
@@ -48,12 +49,6 @@ jobs:
 
     - name: Compiler version
       run: ${{ matrix.compiler }} --version
-      env:
-        CC: ${{ matrix.compiler }}
     - run: cmake .
-      env:
-        CC: ${{ matrix.compiler }}
     - run: make
-      env:
-        CC: ${{ matrix.compiler }}
     - run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ config.h*
 /configure
 stamp-h1
 !config/config.h.in
-/packaging/
 /tests/run-dumper
 /tests/run-emitter
 /tests/run-emitter-test-suite

--- a/.makefile
+++ b/.makefile
@@ -23,6 +23,8 @@ MAKE_TARGETS := \
 	all \
 	all-am \
 	all-recursive \
+	docker-build \
+	docker-dist \
 	install \
 	test \
 	test-all \

--- a/Makefile.am
+++ b/Makefile.am
@@ -17,7 +17,7 @@ maintainer-clean-local:
 	-find ${builddir} -name Makefile.in -exec rm -f '{}' ';'
 
 distclean-local:
-	rm -fr tests/run-test-suite packaging
+	rm -fr tests/run-test-suite
 	-git worktree prune
 
 .PHONY: bootstrap
@@ -43,12 +43,9 @@ ifeq ($(LIBYAML_TEST_SUITE_RUN_REPO),$(LIBYAML_TEST_SUITE_RUN_REPO_DEFAULT))
 	  git clone --branch $(LIBYAML_TEST_SUITE_RUN_BRANCH) $(LIBYAML_TEST_SUITE_RUN_REPO) $@
     endif
 
-packaging:
-	-git branch --track $@ origin/$@
-	git worktree add --force $@ $@
+docker-build:
+	make -C pkg/docker build
 
-docker-dist: packaging
-	make -C $</docker libyaml-dist
+docker-dist:
+	make -C pkg/docker libyaml-dist
 
-docker-test-pyyaml: packaging
-	make -C $</docker test-pyyaml

--- a/pkg/ReadMe.md
+++ b/pkg/ReadMe.md
@@ -1,0 +1,77 @@
+# How to Make a `libyaml` Release
+
+## Versioning
+
+Update libyaml version in:
+* announcement.msg
+* Changes
+* CMakeLists.txt
+  * `YAML_VERSION_MAJOR`, `YAML_VERSION_MINOR`, `YAML_VERSION_PATCH`
+* .appveyor.yml
+* configure.ac
+  * `YAML_MAJOR`, `YAML_MINOR`, `YAML_PATCH`, `YAML_RELEASE`, `YAML_CURRENT`, `YAML_REVISION`
+
+Commit and push everything to `release/0.x.y`.
+
+## Test and Create Release Archives
+
+### GitHub Actions Automation
+
+The github workflow:
+
+    .github/workflows/dist.yaml
+
+will do this automatically for you.
+
+#### .github/workflows/dist.yaml
+
+This workflow will create release archives (`tar.gz` and `zip`).
+
+### Manually
+
+Make sure you have a clean git repository (no changed files).
+The following process will clone your current git directory.
+
+This will need the docker image `yamlio/libyaml-dev`.
+You can either pull it, or create it yourself:
+
+    make docker-build
+
+### Create dist archives
+
+Run:
+
+    make docker-dist
+
+It will run `make dist` in the container to create a tarball written to
+`pkg/docker/output`.
+It will also create a zipfile.
+
+## Update master
+
+    git merge release/0.x.y
+    git tag -a 0.x.y
+    # <Editor opens>
+    # Paste the corresponding entry from the Changes file
+    # Look at an earlier release for how it should look like:
+    #   git show 0.2.3
+    git push origin master 0.x.y
+
+## Create a GitHub release
+
+Go to "Releases" and click on "Draft a new release".
+
+Fill in the tag you just created in the previous step.
+
+Fill in the release title: v0.x.y
+
+Paste the changelog into the description field.
+
+Upload the tar.gz and .zip file.
+
+You can "Save draft" and publish later, or directly click on "Publish release".
+
+## Update pyyaml.org
+
+See <https://github.com/yaml/pyyaml.org/blob/master/ReadMe.md>.
+

--- a/pkg/docker/.gitignore
+++ b/pkg/docker/.gitignore
@@ -1,0 +1,3 @@
+output/*
+!Makefile
+!output/ReadMe

--- a/pkg/docker/Dockerfile
+++ b/pkg/docker/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:18.04
+
+RUN apt-get update \
+ && apt-get install -y \
+        automake \
+        bison \
+        build-essential \
+        cmake \
+        curl \
+        doxygen \
+        flex \
+        git \
+        less \
+        libtool \
+        python \
+        vim \
+        zip \
+ && true
+
+# http://www.doxygen.nl/manual/install.html
+
+RUN curl https://sourceforge.net/projects/doxygen/files/rel-1.8.14/doxygen-1.8.14.src.tar.gz/download \
+        -L -o /doxygen-1.8.14.src.tar.gz \
+ && cd / \
+ && tar -xvf doxygen-1.8.14.src.tar.gz \
+ && cd doxygen-1.8.14 \
+ && mkdir build \
+ && cd build \
+ && cmake -G "Unix Makefiles" .. \
+ && make \
+ && make install \
+ && true

--- a/pkg/docker/Makefile
+++ b/pkg/docker/Makefile
@@ -1,0 +1,23 @@
+DOCKER_IMAGE ?= yamlio/libyaml-dev
+
+build:
+	docker build -t $(DOCKER_IMAGE) .
+
+run: build
+	docker run -it --rm $(DOCKER_IMAGE) bash
+
+prepare-git:
+	rm -rf output/libyaml.git
+	git clone ../../.git output/libyaml.git
+
+libyaml-dist: libyaml-dist-ci
+
+libyaml-dist-ci: prepare-git
+	docker run --rm -u $$(id -u) \
+	  -v"$$PWD/output:/output" \
+	  -v"$$PWD/scripts:/scripts" \
+	  $(DOCKER_IMAGE) /scripts/libyaml-dist.sh
+
+clean:
+	rm -rf output/libyaml.git
+	rm -rf output/yaml-*.*

--- a/pkg/docker/output/ReadMe
+++ b/pkg/docker/output/ReadMe
@@ -1,0 +1,1 @@
+Output directory for build files created by docker

--- a/pkg/docker/scripts/libyaml-dist.sh
+++ b/pkg/docker/scripts/libyaml-dist.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -ex
+
+cp -r /output/libyaml.git /tmp/
+cd /tmp/libyaml.git
+./bootstrap
+./configure
+make dist
+
+# get the tarball filename
+tarballs=(yaml-*.tar.gz)
+tarball=${tarballs[0]:?}
+dirname=${tarball/.tar.gz/}
+
+# Copy to output dir
+cp "$tarball" /output
+
+# Create zip archive
+cd /tmp
+cp "/output/$tarball" .
+tar xvf "$tarball"
+zip -r "/output/$dirname.zip" "$dirname"


### PR DESCRIPTION
This adds two Actions workflows:

* ~~pyyaml-test~~
* dist

~~pyyaml-test will test pyyaml master against libyaml (python2 & 3)~~
dist will create a tar.gz and zip file. The files can be found in the "release" artifact.

It only runs on branches named `release/*` ~~(and pyyaml-test also on `master`)~~.
So it can be tested with `release/test-action` for example.

So for the next release, no local creation of tarballs is necessary anymore.

~~I also added a nightly cronjob for pyyaml-test, so it will regularly test the current PyYYAML master.~~

## Documentation

https://github.com/yaml/libyaml/blob/release/test/pkg/ReadMe.md

## Next steps

A next step could be to automatically create a release like https://github.com/yaml/libyaml/releases/tag/0.2.5 via Actions.

Edit: removed pyyaml-test stuff