### PR TITLE
Whitelist currently passing tests

### DIFF
--- a/blacklist/libyaml-emitter
+++ b/blacklist/libyaml-emitter
@@ -1,9 +1,7 @@
-26DV: Whitespace around colon in mappings
 2EBW: Allowed characters in keys
 2JQS: Block Mapping with Missing Keys
 2LFX: Spec Example 6.13. Reserved Directives [1.3]
 2SXE: Anchors With Colon in Name
-2XXW: Spec Example 2.25. Unordered Sets
 3MYT: Plain Scalar looking like key, comment, anchor and tag
 4ABK: Spec Example 7.17. Flow Mapping Separate Values
 4MUZ: Flow mapping colon on line after key
@@ -11,31 +9,23 @@
 52DL: Explicit Non-Specific Tag [1.3]
 565N: Construct Binary
 5TYM: Spec Example 6.21. Local Tag Prefix
-5WE3: Spec Example 8.17. Explicit Block Mapping Entries
 6CK3: Spec Example 6.26. Tag Shorthands
 6FWR: Block Scalar Keep
-6KGN: Anchor for empty node
 6M2F: Aliases in Explicit Block Mapping
 6PBE: Zero-indented sequences in explicit mapping keys
 6SLA: Allowed characters in quoted mapping key
 6WLZ: Spec Example 6.18. Primary Tag Handle [1.3]
 6WPF: Spec Example 6.8. Flow Folding [1.3]
-6XDY: Two document start markers
 6ZKB: Spec Example 9.6. Stream
 7T8X: Spec Example 8.10. Folded Lines - 8.13. Final Empty Lines
-7W2P: Block Mapping with Missing Values
 7Z25: Bare document after document end marker
-8KB6: Multiline plain flow mapping key without value
 8XYN: Anchor with unicode character
-9BXH: Multiline doublequoted flow mapping key without value
 8MK2: Explicit Non-Specific Tag
 9DXL: Spec Example 9.6. Stream [1.3]
 9MMW: Spec Example 7.21. Single Pair Implicit Entries [1.3
 9TFX: Spec Example 7.6. Double Quoted Lines [1.3]
 B3HG: Spec Example 8.9. Folded Scalar [1.3]
-C2DT: Spec Example 7.18. Flow Mapping Adjacent Values
 DFF7: Spec Example 7.16. Flow Mapping Entries
-E76Z: Aliases in Implicit Block Mapping
 EX5H: Multiline Scalar at Top Level [1.3]
 EXG3: Three dashes and content without space [1.3]
 FBC9: Allowed characters in plain scalars
@@ -43,12 +33,9 @@ FH7J: Tags on Empty Scalars
 FRK4: Spec Example 7.3. Completely Empty Flow Nodes
 J3BT: Spec Example 5.12. Tabs and Spaces
 JDH8: Plain Scalar looking like key, comment, anchor and tag [1.3]
-JTV5: Block Mapping with Multiline Scalars
 K54U: Tab after document header
-KK5P: Various combinations of explicit block mappings
 KSS4: Scalars on --- line
 KZN9: Spec Example 7.21. Single Pair Implicit Entries
-LE5A: Spec Example 7.24. Flow Nodes
 M7A3: Spec Example 9.3. Bare Documents
 M9B4: Spec Example 8.7. Literal Scalar
 NAT4: Various empty or newline only quoted strings
@@ -61,12 +48,7 @@ S4JQ: Spec Example 6.28. Non-Specific Tags
 T26H: Spec Example 8.8. Literal Content [1.3]
 T4YY: Spec Example 7.9. Single Quoted Lines [1.3]
 T5N4: Spec Example 8.7. Literal Scalar [1.3]
-UT92: Spec Example 9.4. Explicit Documents
-W42U: Spec Example 8.15. Block Sequence Entry Types
-W4TN: Spec Example 9.5. Directives Documents
 W5VH: Allowed characters in alias
 WZ62: Spec Example 7.2. Empty Content
-X38W: Aliases in Flow Objects
 XLQ9: Multiline scalar that looks like a YAML directive
 Y2GN: Anchor with colon in the middle
-ZWK4: Key with anchor after missing explicit mapping value

--- a/blacklist/libyaml-parser
+++ b/blacklist/libyaml-parser
@@ -30,5 +30,4 @@ S3PD: Spec Example 8.18. Implicit Block Mapping Entries
 UT92: Spec Example 9.4. Explicit Documents
 W4TN: Spec Example 9.5. Directives Documents
 W5VH: Allowed characters in alias
-WZ62: Spec Example 7.2. Empty Content
 Y2GN: Anchor with colon in the middle


### PR DESCRIPTION
I accidentally discovered that the library is passing some blacklisted tests. Perhaps we could include them? Also, the item
```
8MK2: Explicit Non-Specific Tag
```
is out of order (if the order matters at all).