### PR TITLE
Fix error building on Clang on windows

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -63,7 +63,11 @@ yaml_strdup(const yaml_char_t *str)
     if (!str)
         return NULL;
 
+#ifdef _MSC_VER
     return (yaml_char_t *)strdup((char *)str);
+#else
+    return (yaml_char_t *)strdup((char *)str);
+#endif
 }
 
 /*


### PR DESCRIPTION
Clang apparently doesn't implement strdup in the version of libc they
ship. Instead they implement _strdup which is identical. This change
just makes it so that on windows we just call _strdup in yaml_strdup.