### PR TITLE
Explicitly specify the YAML version 1.1 in README

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,4 +1,4 @@
-## LibYAML - A C library for parsing and emitting YAML.
+## LibYAML - A C library for parsing and emitting YAML 1.1
 
 To build and install the library, run:
 


### PR DESCRIPTION
The version of the supported YAML is a crucial piece of information for those who want to minimize the surprises caused by earlier version of YAML. 