### PR TITLE
build: Don't use both -release and -version-info.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
 AM_CPPFLAGS = -I$(top_srcdir)/include -Wall
 lib_LTLIBRARIES = libyaml.la
 libyaml_la_SOURCES = yaml_private.h api.c reader.c scanner.c parser.c loader.c writer.c emitter.c dumper.c
-libyaml_la_LDFLAGS = -no-undefined -release $(YAML_LT_RELEASE) -version-info $(YAML_LT_CURRENT):$(YAML_LT_REVISION):$(YAML_LT_AGE)
+libyaml_la_LDFLAGS = -no-undefined -version-info $(YAML_LT_CURRENT):$(YAML_LT_REVISION):$(YAML_LT_AGE)


### PR DESCRIPTION
GNU libtool documentation says that these should not be used at the same time.
```
-release release

    Specify that the library was generated by release release of your package, so that users 
    can easily tell what versions are newer than others. Be warned that no two releases of your
    package will be binary compatible if you use this flag. If you want binary compatibility, use the
    -version-info flag instead (see Versioning).
```
```
-version-info current[:revision[:age]]

    If output-file is a libtool library, use interface version information current, revision, and 
    age to build it (see Versioning). Do not use this flag to specify package release information,
    rather see the -release flag.
```
https://www.gnu.org/software/libtool/manual/libtool.html

When using slibtool (https://dev.midipix.org/cross/slibtool) it fails to create the `libyaml-0.so.2` symlink which can break builds that depend on libyaml. On the other hand GNU libtool seems to silently ignore `-release` here.