### PR TITLE
Fix some typos

### DIFF
--- a/examples/strings.yaml
+++ b/examples/strings.yaml
@@ -1,4 +1,4 @@
-unqouted: string
+unquoted: string
 literal-block: |
     This entire block of text will be the value of the 'literal-block' key,
     with line breaks being preserved.

--- a/include/yaml.h
+++ b/include/yaml.h
@@ -1095,7 +1095,7 @@ typedef struct yaml_parser_s {
     yaml_error_type_t error;
     /** Error description. */
     const char *problem;
-    /** The byte about which the problem occured. */
+    /** The byte about which the problem occurred. */
     size_t problem_offset;
     /** The problematic value (@c -1 is none). */
     int problem_value;
@@ -1335,7 +1335,7 @@ yaml_parser_delete(yaml_parser_t *parser);
  * Set a string input.
  *
  * Note that the @a input pointer must be valid while the @a parser object
- * exists.  The application is responsible for destroing @a input after
+ * exists.  The application is responsible for destroying @a input after
  * destroying the @a parser.
  *
  * @param[in,out]   parser  A parser object.
@@ -1748,7 +1748,7 @@ typedef struct yaml_emitter_s {
         size_t length;
         /** Does the scalar contain line breaks? */
         int multiline;
-        /** Can the scalar be expessed in the flow plain style? */
+        /** Can the scalar be expressed in the flow plain style? */
         int flow_plain_allowed;
         /** Can the scalar be expressed in the block plain style? */
         int block_plain_allowed;
@@ -1964,7 +1964,7 @@ yaml_emitter_close(yaml_emitter_t *emitter);
 /**
  * Emit a YAML document.
  *
- * The documen object may be generated using the yaml_parser_load() function
+ * The document object may be generated using the yaml_parser_load() function
  * or the yaml_document_initialize() function.  The emitter takes the
  * responsibility for the document object and destroys its content after
  * it is emitted. The document object is destroyed even if the function fails.

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -273,7 +273,7 @@
  * The tokens BLOCK-SEQUENCE-START and BLOCK-MAPPING-START denote indentation
  * increase that precedes a block collection (cf. the INDENT token in Python).
  * The token BLOCK-END denote indentation decrease that ends a block collection
- * (cf. the DEDENT token in Python).  However YAML has some syntax pecularities
+ * (cf. the DEDENT token in Python).  However YAML has some syntax peculiarities
  * that makes detections of these tokens more complex.
  *
  * The tokens BLOCK-ENTRY, KEY, and VALUE are used to represent the indicators
@@ -3287,7 +3287,7 @@ yaml_parser_scan_flow_scalar(yaml_parser_t *parser, yaml_token_t *token,
 
         /* Check if we are at the end of the scalar. */
 
-        /* Fix for crash unitialized value crash
+        /* Fix for crash uninitialized value crash
          * Credit for the bug and input is to OSS Fuzz
          * Credit for the fix to Alex Gaynor
          */

--- a/tests/run-emitter-test-suite.c
+++ b/tests/run-emitter-test-suite.c
@@ -72,7 +72,7 @@ int main(int argc, char *argv[])
     assert(input);
 
     if (!yaml_emitter_initialize(&emitter)) {
-        fprintf(stderr, "Could not initalize the emitter object\n");
+        fprintf(stderr, "Could not initialize the emitter object\n");
         return 1;
     }
     yaml_emitter_set_output_file(&emitter, stdout);

--- a/tests/test-reader.c
+++ b/tests/test-reader.c
@@ -103,7 +103,7 @@ test_case utf8_sequences[] = {
 
 test_case boms[] = {
     
-    /* {"title", "test!", lenth}, */
+    /* {"title", "test!", length}, */
     
     {"no bom (utf-8)", "Hi is \xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82!", 13},
     {"bom (utf-8)", "\xef\xbb\xbfHi is \xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82!", 13},


### PR DESCRIPTION
I've just known that the upstream of under `ext/psych/yaml/` in https://github.com/ruby/psych is libyaml.

https://github.com/ruby/psych/pull/484#issuecomment-826418572