### PR TITLE
📌 Fix README typos

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -12,7 +12,7 @@ Required packages:
 - libtool
 - make
 
-If you checked the source code from the Git repository, run
+If you checked the source code from the Git repository, run:
 
     $ ./bootstrap
     $ ./configure


### PR DESCRIPTION
### Changes made
I added a colon after `run` on _line 15_.

```markdown
❌ If you checked the source code from the Git repository, run
---
✅ If you checked the source code from the Git repository, run:
```
### Reasoning
The colon was included after the `run` on _line 3_ and after `packages` on _line 9_.