### PR TITLE
Helpful assert errors

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -176,7 +176,7 @@ yaml_queue_extend(void **start, void **head, void **tail, void **end)
 YAML_DECLARE(int)
 yaml_parser_initialize(yaml_parser_t *parser)
 {
-    assert(parser);     /* Non-NULL parser object expected. */
+    assert(parser && "Non-NULL parser object expected.");
 
     memset(parser, 0, sizeof(yaml_parser_t));
     if (!BUFFER_INIT(parser, parser->raw_buffer, INPUT_RAW_BUFFER_SIZE))
@@ -219,7 +219,7 @@ error:
 YAML_DECLARE(void)
 yaml_parser_delete(yaml_parser_t *parser)
 {
-    assert(parser); /* Non-NULL parser object expected. */
+    assert(parser && "Non-NULL parser object expected.");
 
     BUFFER_DEL(parser, parser->raw_buffer);
     BUFFER_DEL(parser, parser->buffer);
@@ -289,9 +289,9 @@ YAML_DECLARE(void)
 yaml_parser_set_input_string(yaml_parser_t *parser,
         const unsigned char *input, size_t size)
 {
-    assert(parser); /* Non-NULL parser object expected. */
-    assert(!parser->read_handler);  /* You can set the source only once. */
-    assert(input);  /* Non-NULL input string expected. */
+    assert(parser && "Non-NULL parser object expected.");
+    assert(!parser->read_handler && "You can set the source only once.");
+    assert(input && "Non-NULL input string expected.");
 
     parser->read_handler = yaml_string_read_handler;
     parser->read_handler_data = parser;
@@ -308,9 +308,9 @@ yaml_parser_set_input_string(yaml_parser_t *parser,
 YAML_DECLARE(void)
 yaml_parser_set_input_file(yaml_parser_t *parser, FILE *file)
 {
-    assert(parser); /* Non-NULL parser object expected. */
-    assert(!parser->read_handler);  /* You can set the source only once. */
-    assert(file);   /* Non-NULL file object expected. */
+    assert(parser && "Non-NULL parser object expected.");
+    assert(!parser->read_handler && "You can set the source only once.");
+    assert(file && "Non-NULL file object expected.");
 
     parser->read_handler = yaml_file_read_handler;
     parser->read_handler_data = parser;
@@ -326,9 +326,9 @@ YAML_DECLARE(void)
 yaml_parser_set_input(yaml_parser_t *parser,
         yaml_read_handler_t *handler, void *data)
 {
-    assert(parser); /* Non-NULL parser object expected. */
-    assert(!parser->read_handler);  /* You can set the source only once. */
-    assert(handler);    /* Non-NULL read handler expected. */
+    assert(parser && "Non-NULL parser object expected.");
+    assert(!parser->read_handler && "You can set the source only once.");
+    assert(handler && "Non-NULL read handler expected.");
 
     parser->read_handler = handler;
     parser->read_handler_data = data;
@@ -341,8 +341,8 @@ yaml_parser_set_input(yaml_parser_t *parser,
 YAML_DECLARE(void)
 yaml_parser_set_encoding(yaml_parser_t *parser, yaml_encoding_t encoding)
 {
-    assert(parser); /* Non-NULL parser object expected. */
-    assert(!parser->encoding); /* Encoding is already set or detected. */
+    assert(parser && "Non-NULL parser object expected.");
+    assert(!parser->encoding && "Encoding is already set or detected.");
 
     parser->encoding = encoding;
 }
@@ -354,7 +354,7 @@ yaml_parser_set_encoding(yaml_parser_t *parser, yaml_encoding_t encoding)
 YAML_DECLARE(int)
 yaml_emitter_initialize(yaml_emitter_t *emitter)
 {
-    assert(emitter);    /* Non-NULL emitter object expected. */
+    assert(emitter && "Non-NULL emitter object expected.");
 
     memset(emitter, 0, sizeof(yaml_emitter_t));
     if (!BUFFER_INIT(emitter, emitter->buffer, OUTPUT_BUFFER_SIZE))
@@ -391,7 +391,7 @@ error:
 YAML_DECLARE(void)
 yaml_emitter_delete(yaml_emitter_t *emitter)
 {
-    assert(emitter);    /* Non-NULL emitter object expected. */
+    assert(emitter && "Non-NULL emitter object expected.");
 
     BUFFER_DEL(emitter, emitter->buffer);
     BUFFER_DEL(emitter, emitter->raw_buffer);
@@ -457,9 +457,9 @@ YAML_DECLARE(void)
 yaml_emitter_set_output_string(yaml_emitter_t *emitter,
         unsigned char *output, size_t size, size_t *size_written)
 {
-    assert(emitter);    /* Non-NULL emitter object expected. */
-    assert(!emitter->write_handler);    /* You can set the output only once. */
-    assert(output);     /* Non-NULL output string expected. */
+    assert(emitter && "Non-NULL emitter object expected.");
+    assert(!emitter->write_handler && "You can set the output only once.");
+    assert(output && "Non-NULL output string expected.");
 
     emitter->write_handler = yaml_string_write_handler;
     emitter->write_handler_data = emitter;
@@ -477,9 +477,9 @@ yaml_emitter_set_output_string(yaml_emitter_t *emitter,
 YAML_DECLARE(void)
 yaml_emitter_set_output_file(yaml_emitter_t *emitter, FILE *file)
 {
-    assert(emitter);    /* Non-NULL emitter object expected. */
-    assert(!emitter->write_handler);    /* You can set the output only once. */
-    assert(file);       /* Non-NULL file object expected. */
+    assert(emitter && "Non-NULL emitter object expected.");
+    assert(!emitter->write_handler && "You can set the output only once.");
+    assert(file && "Non-NULL file object expected.");
 
     emitter->write_handler = yaml_file_write_handler;
     emitter->write_handler_data = emitter;
@@ -495,9 +495,9 @@ YAML_DECLARE(void)
 yaml_emitter_set_output(yaml_emitter_t *emitter,
         yaml_write_handler_t *handler, void *data)
 {
-    assert(emitter);    /* Non-NULL emitter object expected. */
-    assert(!emitter->write_handler);    /* You can set the output only once. */
-    assert(handler);    /* Non-NULL handler object expected. */
+    assert(emitter && "Non-NULL emitter object expected.");
+    assert(!emitter->write_handler && "You can set the output only once.");
+    assert(handler && "Non-NULL handler object expected.");
 
     emitter->write_handler = handler;
     emitter->write_handler_data = data;
@@ -510,8 +510,8 @@ yaml_emitter_set_output(yaml_emitter_t *emitter,
 YAML_DECLARE(void)
 yaml_emitter_set_encoding(yaml_emitter_t *emitter, yaml_encoding_t encoding)
 {
-    assert(emitter);    /* Non-NULL emitter object expected. */
-    assert(!emitter->encoding);     /* You can set encoding only once. */
+    assert(emitter && "Non-NULL emitter object expected.");
+    assert(!emitter->encoding && "You can set encoding only once.");
 
     emitter->encoding = encoding;
 }
@@ -523,7 +523,7 @@ yaml_emitter_set_encoding(yaml_emitter_t *emitter, yaml_encoding_t encoding)
 YAML_DECLARE(void)
 yaml_emitter_set_canonical(yaml_emitter_t *emitter, int canonical)
 {
-    assert(emitter);    /* Non-NULL emitter object expected. */
+    assert(emitter && "Non-NULL emitter object expected.");
 
     emitter->canonical = (canonical != 0);
 }
@@ -535,7 +535,7 @@ yaml_emitter_set_canonical(yaml_emitter_t *emitter, int canonical)
 YAML_DECLARE(void)
 yaml_emitter_set_indent(yaml_emitter_t *emitter, int indent)
 {
-    assert(emitter);    /* Non-NULL emitter object expected. */
+    assert(emitter && "Non-NULL emitter object expected.");
 
     emitter->best_indent = (1 < indent && indent < 10) ? indent : 2;
 }
@@ -547,7 +547,7 @@ yaml_emitter_set_indent(yaml_emitter_t *emitter, int indent)
 YAML_DECLARE(void)
 yaml_emitter_set_width(yaml_emitter_t *emitter, int width)
 {
-    assert(emitter);    /* Non-NULL emitter object expected. */
+    assert(emitter && "Non-NULL emitter object expected.");
 
     emitter->best_width = (width >= 0) ? width : -1;
 }
@@ -559,7 +559,7 @@ yaml_emitter_set_width(yaml_emitter_t *emitter, int width)
 YAML_DECLARE(void)
 yaml_emitter_set_unicode(yaml_emitter_t *emitter, int unicode)
 {
-    assert(emitter);    /* Non-NULL emitter object expected. */
+    assert(emitter && "Non-NULL emitter object expected.");
 
     emitter->unicode = (unicode != 0);
 }
@@ -571,7 +571,7 @@ yaml_emitter_set_unicode(yaml_emitter_t *emitter, int unicode)
 YAML_DECLARE(void)
 yaml_emitter_set_break(yaml_emitter_t *emitter, yaml_break_t line_break)
 {
-    assert(emitter);    /* Non-NULL emitter object expected. */
+    assert(emitter && "Non-NULL emitter object expected.");
 
     emitter->line_break = line_break;
 }
@@ -583,7 +583,7 @@ yaml_emitter_set_break(yaml_emitter_t *emitter, yaml_break_t line_break)
 YAML_DECLARE(void)
 yaml_token_delete(yaml_token_t *token)
 {
-    assert(token);  /* Non-NULL token object expected. */
+    assert(token && "Non-NULL token object expected.");
 
     switch (token->type)
     {
@@ -671,7 +671,7 @@ yaml_stream_start_event_initialize(yaml_event_t *event,
 {
     yaml_mark_t mark = { 0, 0, 0 };
 
-    assert(event);  /* Non-NULL event object is expected. */
+    assert(event && "Non-NULL event object is expected.");
 
     STREAM_START_EVENT_INIT(*event, encoding, mark, mark);
 
@@ -687,7 +687,7 @@ yaml_stream_end_event_initialize(yaml_event_t *event)
 {
     yaml_mark_t mark = { 0, 0, 0 };
 
-    assert(event);  /* Non-NULL event object is expected. */
+    assert(event && "Non-NULL event object is expected.");
 
     STREAM_END_EVENT_INIT(*event, mark, mark);
 
@@ -717,10 +717,9 @@ yaml_document_start_event_initialize(yaml_event_t *event,
     } tag_directives_copy = { NULL, NULL, NULL };
     yaml_tag_directive_t value = { NULL, NULL };
 
-    assert(event);          /* Non-NULL event object is expected. */
-    assert((tag_directives_start && tag_directives_end) ||
-            (tag_directives_start == tag_directives_end));
-                            /* Valid tag directives are expected. */
+    assert(event && "Non-NULL event object is expected.");
+    assert(((tag_directives_start && tag_directives_end) ||
+            (tag_directives_start == tag_directives_end) ) && "Valid tag directives are expected.");
 
     if (version_directive) {
         version_directive_copy = YAML_MALLOC_STATIC(yaml_version_directive_t);
@@ -735,8 +734,8 @@ yaml_document_start_event_initialize(yaml_event_t *event,
             goto error;
         for (tag_directive = tag_directives_start;
                 tag_directive != tag_directives_end; tag_directive ++) {
-            assert(tag_directive->handle);
-            assert(tag_directive->prefix);
+            assert(tag_directive->handle && "Non-NULL tag directive handle expected");
+            assert(tag_directive->prefix && "Non-NULL tag directive prefix expected");
             if (!yaml_check_utf8(tag_directive->handle,
                         strlen((char *)tag_directive->handle)))
                 goto error;
@@ -782,7 +781,7 @@ yaml_document_end_event_initialize(yaml_event_t *event, int implicit)
 {
     yaml_mark_t mark = { 0, 0, 0 };
 
-    assert(event);      /* Non-NULL emitter object is expected. */
+    assert(event && "Non-NULL emitter object is expected.");
 
     DOCUMENT_END_EVENT_INIT(*event, implicit, mark, mark);
 
@@ -799,8 +798,8 @@ yaml_alias_event_initialize(yaml_event_t *event, const yaml_char_t *anchor)
     yaml_mark_t mark = { 0, 0, 0 };
     yaml_char_t *anchor_copy = NULL;
 
-    assert(event);      /* Non-NULL event object is expected. */
-    assert(anchor);     /* Non-NULL anchor is expected. */
+    assert(event && "Non-NULL event object is expected.");
+    assert(anchor && "Non-NULL anchor is expected.");
 
     if (!yaml_check_utf8(anchor, strlen((char *)anchor))) return 0;
 
@@ -829,8 +828,8 @@ yaml_scalar_event_initialize(yaml_event_t *event,
     yaml_char_t *tag_copy = NULL;
     yaml_char_t *value_copy = NULL;
 
-    assert(event);      /* Non-NULL event object is expected. */
-    assert(value);      /* Non-NULL anchor is expected. */
+    assert(event && "Non-NULL event object is expected.");
+    assert(value && "Non-NULL value is expected.");
 
     if (anchor) {
         if (!yaml_check_utf8(anchor, strlen((char *)anchor))) goto error;
@@ -880,7 +879,7 @@ yaml_sequence_start_event_initialize(yaml_event_t *event,
     yaml_char_t *anchor_copy = NULL;
     yaml_char_t *tag_copy = NULL;
 
-    assert(event);      /* Non-NULL event object is expected. */
+    assert(event && "Non-NULL event object is expected.");
 
     if (anchor) {
         if (!yaml_check_utf8(anchor, strlen((char *)anchor))) goto error;
@@ -915,7 +914,7 @@ yaml_sequence_end_event_initialize(yaml_event_t *event)
 {
     yaml_mark_t mark = { 0, 0, 0 };
 
-    assert(event);      /* Non-NULL event object is expected. */
+    assert(event && "Non-NULL event object is expected.");
 
     SEQUENCE_END_EVENT_INIT(*event, mark, mark);
 
@@ -935,7 +934,7 @@ yaml_mapping_start_event_initialize(yaml_event_t *event,
     yaml_char_t *anchor_copy = NULL;
     yaml_char_t *tag_copy = NULL;
 
-    assert(event);      /* Non-NULL event object is expected. */
+    assert(event && "Non-NULL event object is expected.");
 
     if (anchor) {
         if (!yaml_check_utf8(anchor, strlen((char *)anchor))) goto error;
@@ -970,7 +969,7 @@ yaml_mapping_end_event_initialize(yaml_event_t *event)
 {
     yaml_mark_t mark = { 0, 0, 0 };
 
-    assert(event);      /* Non-NULL event object is expected. */
+    assert(event && "Non-NULL event object is expected.");
 
     MAPPING_END_EVENT_INIT(*event, mark, mark);
 
@@ -986,7 +985,7 @@ yaml_event_delete(yaml_event_t *event)
 {
     yaml_tag_directive_t *tag_directive;
 
-    assert(event);  /* Non-NULL event object expected. */
+    assert(event && "Non-NULL event object expected.");
 
     switch (event->type)
     {
@@ -1056,10 +1055,10 @@ yaml_document_initialize(yaml_document_t *document,
     yaml_tag_directive_t value = { NULL, NULL };
     yaml_mark_t mark = { 0, 0, 0 };
 
-    assert(document);       /* Non-NULL document object is expected. */
-    assert((tag_directives_start && tag_directives_end) ||
-            (tag_directives_start == tag_directives_end));
-                            /* Valid tag directives are expected. */
+    assert(document && "Non-NULL document object is expected. ");
+    assert(((tag_directives_start && tag_directives_end) ||
+            (tag_directives_start == tag_directives_end)) &&
+             "Valid tag directives are expected.");
 
     if (!STACK_INIT(&context, nodes, yaml_node_t*)) goto error;
 
@@ -1076,8 +1075,8 @@ yaml_document_initialize(yaml_document_t *document,
             goto error;
         for (tag_directive = tag_directives_start;
                 tag_directive != tag_directives_end; tag_directive ++) {
-            assert(tag_directive->handle);
-            assert(tag_directive->prefix);
+            assert(tag_directive->handle && "A non-NULL tag directive handle is expected");
+            assert(tag_directive->prefix && "A non-NULL tag directive prefix is expected");
             if (!yaml_check_utf8(tag_directive->handle,
                         strlen((char *)tag_directive->handle)))
                 goto error;
@@ -1124,7 +1123,7 @@ yaml_document_delete(yaml_document_t *document)
 {
     yaml_tag_directive_t *tag_directive;
 
-    assert(document);   /* Non-NULL document object is expected. */
+    assert(document && "Non-NULL document object is expected.");
 
     while (!STACK_EMPTY(&context, document->nodes)) {
         yaml_node_t node = POP(&context, document->nodes);
@@ -1140,7 +1139,7 @@ yaml_document_delete(yaml_document_t *document)
                 STACK_DEL(&context, node.data.mapping.pairs);
                 break;
             default:
-                assert(0);  /* Should not happen. */
+                assert(0 && "Should not happen.");
         }
     }
     STACK_DEL(&context, document->nodes);
@@ -1164,7 +1163,7 @@ yaml_document_delete(yaml_document_t *document)
 YAML_DECLARE(yaml_node_t *)
 yaml_document_get_node(yaml_document_t *document, int index)
 {
-    assert(document);   /* Non-NULL document object is expected. */
+    assert(document && "Non-NULL document object is expected.");
 
     if (index > 0 && document->nodes.start + index <= document->nodes.top) {
         return document->nodes.start + index - 1;
@@ -1179,7 +1178,7 @@ yaml_document_get_node(yaml_document_t *document, int index)
 YAML_DECLARE(yaml_node_t *)
 yaml_document_get_root_node(yaml_document_t *document)
 {
-    assert(document);   /* Non-NULL document object is expected. */
+    assert(document && "Non-NULL document object is expected. ");
 
     if (document->nodes.top != document->nodes.start) {
         return document->nodes.start;
@@ -1204,8 +1203,8 @@ yaml_document_add_scalar(yaml_document_t *document,
     yaml_char_t *value_copy = NULL;
     yaml_node_t node;
 
-    assert(document);   /* Non-NULL document object is expected. */
-    assert(value);      /* Non-NULL value is expected. */
+    assert(document && "Non-NULL document object is expected.");
+    assert(value && "Non-NULL value is expected.");
 
     if (!tag) {
         tag = (yaml_char_t *)YAML_DEFAULT_SCALAR_TAG;
@@ -1257,7 +1256,7 @@ yaml_document_add_sequence(yaml_document_t *document,
     } items = { NULL, NULL, NULL };
     yaml_node_t node;
 
-    assert(document);   /* Non-NULL document object is expected. */
+    assert(document && "Non-NULL document object is expected.");
 
     if (!tag) {
         tag = (yaml_char_t *)YAML_DEFAULT_SEQUENCE_TAG;
@@ -1302,7 +1301,7 @@ yaml_document_add_mapping(yaml_document_t *document,
     } pairs = { NULL, NULL, NULL };
     yaml_node_t node;
 
-    assert(document);   /* Non-NULL document object is expected. */
+    assert(document && "Non-NULL document object is expected.");
 
     if (!tag) {
         tag = (yaml_char_t *)YAML_DEFAULT_MAPPING_TAG;
@@ -1339,14 +1338,15 @@ yaml_document_append_sequence_item(yaml_document_t *document,
         yaml_error_type_t error;
     } context;
 
-    assert(document);       /* Non-NULL document is required. */
+    assert(document && "Non-NULL document is required.");
     assert(sequence > 0
-            && document->nodes.start + sequence <= document->nodes.top);
-                            /* Valid sequence id is required. */
-    assert(document->nodes.start[sequence-1].type == YAML_SEQUENCE_NODE);
-                            /* A sequence node is required. */
-    assert(item > 0 && document->nodes.start + item <= document->nodes.top);
-                            /* Valid item id is required. */
+           && document->nodes.start + sequence <= document->nodes.top
+           && "Valid sequence id is required.");
+    assert(document->nodes.start[sequence-1].type == YAML_SEQUENCE_NODE
+           && "A sequence node is required.");
+    assert(item > 0
+           && document->nodes.start + item <= document->nodes.top
+           && "Valid item id is required.");
 
     if (!PUSH(&context,
                 document->nodes.start[sequence-1].data.sequence.items, item))
@@ -1369,16 +1369,18 @@ yaml_document_append_mapping_pair(yaml_document_t *document,
 
     yaml_node_pair_t pair;
 
-    assert(document);       /* Non-NULL document is required. */
+    assert(document && "Non-NULL document is required.");
     assert(mapping > 0
-            && document->nodes.start + mapping <= document->nodes.top);
-                            /* Valid mapping id is required. */
-    assert(document->nodes.start[mapping-1].type == YAML_MAPPING_NODE);
-                            /* A mapping node is required. */
-    assert(key > 0 && document->nodes.start + key <= document->nodes.top);
-                            /* Valid key id is required. */
-    assert(value > 0 && document->nodes.start + value <= document->nodes.top);
-                            /* Valid value id is required. */
+           && document->nodes.start + mapping <= document->nodes.top
+           && "Valid mapping id is required.");
+    assert(document->nodes.start[mapping-1].type == YAML_MAPPING_NODE
+           && "A mapping node is required.");
+    assert(key > 0
+           && document->nodes.start + key <= document->nodes.top
+           && "Valid key id is required.");
+    assert(value > 0
+           && document->nodes.start + value <= document->nodes.top
+           && "Valid value id is required.");
 
     pair.key = key;
     pair.value = value;

--- a/src/dumper.c
+++ b/src/dumper.c
@@ -64,8 +64,8 @@ yaml_emitter_open(yaml_emitter_t *emitter)
     yaml_event_t event;
     yaml_mark_t mark = { 0, 0, 0 };
 
-    assert(emitter);            /* Non-NULL emitter object is required. */
-    assert(!emitter->opened);   /* Emitter should not be opened yet. */
+    assert(emitter && "Non-NULL emitter object is required.");
+    assert(!emitter->opened && "Emitter should not be opened yet.");
 
     STREAM_START_EVENT_INIT(event, YAML_ANY_ENCODING, mark, mark);
 
@@ -88,8 +88,8 @@ yaml_emitter_close(yaml_emitter_t *emitter)
     yaml_event_t event;
     yaml_mark_t mark = { 0, 0, 0 };
 
-    assert(emitter);            /* Non-NULL emitter object is required. */
-    assert(emitter->opened);    /* Emitter should be opened. */
+    assert(emitter && "Non-NULL emitter object is required.");
+    assert(emitter->opened && "Emitter should be opened.");
 
     if (emitter->closed) return 1;
 
@@ -114,8 +114,8 @@ yaml_emitter_dump(yaml_emitter_t *emitter, yaml_document_t *document)
     yaml_event_t event;
     yaml_mark_t mark = { 0, 0, 0 };
 
-    assert(emitter);            /* Non-NULL emitter object is required. */
-    assert(document);           /* Non-NULL emitter object is expected. */
+    assert(emitter && "Non-NULL emitter object is required.");
+    assert(document && "Non-NULL emitter object is expected.");
 
     emitter->document = document;
 
@@ -129,7 +129,7 @@ yaml_emitter_dump(yaml_emitter_t *emitter, yaml_document_t *document)
         return 1;
     }
 
-    assert(emitter->opened);    /* Emitter should be opened. */
+    assert(emitter->opened && "Emitter should be opened.");
 
     emitter->anchors = (yaml_anchors_t*)yaml_malloc(sizeof(*(emitter->anchors))
             * (document->nodes.top - document->nodes.start));
@@ -286,7 +286,7 @@ yaml_emitter_dump_node(yaml_emitter_t *emitter, int index)
         case YAML_MAPPING_NODE:
             return yaml_emitter_dump_mapping(emitter, node, anchor);
         default:
-            assert(0);      /* Could not happen. */
+            assert(0 && "Could not happen.");
             break;
     }
 

--- a/src/emitter.c
+++ b/src/emitter.c
@@ -481,7 +481,7 @@ yaml_emitter_state_machine(yaml_emitter_t *emitter, yaml_event_t *event)
                     "expected nothing after STREAM-END");
 
         default:
-            assert(1);      /* Invalid state. */
+            assert(0 && "Invalid state.");
     }
 
     return 0;
@@ -1338,7 +1338,7 @@ yaml_emitter_process_scalar(yaml_emitter_t *emitter)
                     emitter->scalar_data.value, emitter->scalar_data.length);
 
         default:
-            assert(1);      /* Impossible. */
+            assert(0 && "Impossible.");
     }
 
     return 0;

--- a/src/loader.c
+++ b/src/loader.c
@@ -88,8 +88,8 @@ yaml_parser_load(yaml_parser_t *parser, yaml_document_t *document)
 {
     yaml_event_t event;
 
-    assert(parser);     /* Non-NULL parser object is expected. */
-    assert(document);   /* Non-NULL document object is expected. */
+    assert(parser && "Non-NULL parser object is expected.");
+    assert(document && "Non-NULL document object is expected.");
 
     memset(document, 0, sizeof(yaml_document_t));
     if (!STACK_INIT(parser, document->nodes, yaml_node_t*))
@@ -97,8 +97,8 @@ yaml_parser_load(yaml_parser_t *parser, yaml_document_t *document)
 
     if (!parser->stream_start_produced) {
         if (!yaml_parser_parse(parser, &event)) goto error;
-        assert(event.type == YAML_STREAM_START_EVENT);
-                        /* STREAM-START is expected. */
+        assert(event.type == YAML_STREAM_START_EVENT 
+               && "STREAM-START is expected.");
     }
 
     if (parser->stream_end_produced) {
@@ -186,8 +186,8 @@ yaml_parser_load_document(yaml_parser_t *parser, yaml_event_t *event)
 {
     struct loader_ctx ctx = { NULL, NULL, NULL };
 
-    assert(event->type == YAML_DOCUMENT_START_EVENT);
-                        /* DOCUMENT-START is expected. */
+    assert(event->type == YAML_DOCUMENT_START_EVENT
+           && "DOCUMENT-START is expected.");
 
     parser->document->version_directive
         = event->data.document_start.version_directive;
@@ -243,7 +243,7 @@ yaml_parser_load_nodes(yaml_parser_t *parser, struct loader_ctx *ctx)
                     return 0;
                 break;
             default:
-                assert(0);  /* Could not happen. */
+                assert(0 && "yaml_parse Case Failure");  /* Could not happen. */
                 return 0;
             case YAML_DOCUMENT_END_EVENT:
                 break;
@@ -337,7 +337,7 @@ yaml_parser_load_node_add(yaml_parser_t *parser, struct loader_ctx *ctx,
             break;
         }
         default:
-            assert(0); /* Could not happen. */
+            assert(0 && "YAML SEQ/MAP case failure."); /* Could not happen. */
             return 0;
     }
     return 1;

--- a/src/parser.c
+++ b/src/parser.c
@@ -169,8 +169,8 @@ yaml_parser_append_tag_directive(yaml_parser_t *parser,
 YAML_DECLARE(int)
 yaml_parser_parse(yaml_parser_t *parser, yaml_event_t *event)
 {
-    assert(parser);     /* Non-NULL parser object is expected. */
-    assert(event);      /* Non-NULL event object is expected. */
+    assert(parser && "Non-NULL parser object is expected.");
+    assert(event && "Non-NULL event object is expected.");
 
     /* Erase the event object. */
 
@@ -297,7 +297,7 @@ yaml_parser_state_machine(yaml_parser_t *parser, yaml_event_t *event)
             return yaml_parser_parse_flow_mapping_value(parser, event, 1);
 
         default:
-            assert(1);      /* Invalid state. */
+            assert(0 && "Invalid state.");
     }
 
     return 0;

--- a/src/reader.c
+++ b/src/reader.c
@@ -143,7 +143,7 @@ yaml_parser_update_buffer(yaml_parser_t *parser, size_t length)
 {
     int first = 1;
 
-    assert(parser->read_handler);   /* Read handler must be set. */
+    assert(parser->read_handler && "Read handler must be set.");
 
     /* If the EOF flag is set and the raw buffer is empty, do nothing. */
 
@@ -394,7 +394,7 @@ yaml_parser_update_buffer(yaml_parser_t *parser, size_t length)
                     break;
 
                 default:
-                    assert(1);      /* Impossible. */
+                    assert(0 && "Impossible.");
             }
 
             /* Check if the raw buffer contains enough bytes to form a character. */

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -742,8 +742,8 @@ yaml_parser_scan_plain_scalar(yaml_parser_t *parser, yaml_token_t *token);
 YAML_DECLARE(int)
 yaml_parser_scan(yaml_parser_t *parser, yaml_token_t *token)
 {
-    assert(parser); /* Non-NULL parser object is expected. */
-    assert(token);  /* Non-NULL token object is expected. */
+    assert(parser && "Non-NULL parser object is expected.");
+    assert(token && "Non-NULL token object is expected.");
 
     /* Erase the token object. */
 

--- a/src/writer.c
+++ b/src/writer.c
@@ -33,9 +33,9 @@ yaml_emitter_flush(yaml_emitter_t *emitter)
 {
     int low, high;
 
-    assert(emitter);    /* Non-NULL emitter object is expected. */
-    assert(emitter->write_handler); /* Write handler must be set. */
-    assert(emitter->encoding);  /* Output encoding must be set. */
+    assert(emitter && "Non-NULL emitter object is expected.");
+    assert(emitter->write_handler && "Write handler must be set.");
+    assert(emitter->encoding && "Output encoding must be set.");
 
     emitter->buffer.last = emitter->buffer.pointer;
     emitter->buffer.pointer = emitter->buffer.start;


### PR DESCRIPTION
Original at https://github.com/vubiostat/r-yaml/issues/22

Per Tim Hesterberg:

In C, the assert macro takes a boolean value, or something that can convert to a boolean value. At run time, if this value is true, nothing happens and the program continues. On false, an assertion is raised, the program crashes, and the line with the assert is printed out. So an assertion written:

assert(size > 0);

Would get something like this when the assertion is triggered:

Assertion failed: 'size > 0'

Probably with more information like file name, line number, etc. However, there is no second argument to assert to specify why the assert exists. To do that, a string literal can be inserted into the boolean argument like so:

assert(size > 0 && "need at least one element");
Assertion failed: 'size > 0 && "need at least one element"'

The string literal has the type of a character array. Arrays can decay to a pointer to the element type. Pointers can convert to boolean value, with non-null pointers becoming a true value. Arrays that decay to pointers always decay to non-null pointers. This means that string literals in a boolean context evaluate to true. By boolean logic, (X && true) == (X), so it is safe to append '&& "message"' to any boolean expression without changing its value.

If there is a code path that should never be reached, an assertion that always fails should be inserted. The smallest such form is:

assert(0);

Then, if a message is required:

assert(0 && "oops");

Both the arguments evaluate to false and the assertion always triggers. However, a common mistake with asserts is to omit the '0 &&' and write:

assert("oops");

With this mistake, "oops" always evaluated to true, the assertion never triggers, and this code branch is no longer protected. I think it's a good idea to pass on to the package maintainer so that future versions will not have this problem.