### PR TITLE
Control Indent Mapping Context

### DIFF
--- a/include/yaml.h
+++ b/include/yaml.h
@@ -1493,7 +1493,6 @@ typedef enum yaml_emitter_state_e {
     YAML_EMIT_DOCUMENT_CONTENT_STATE,
     /** Expect DOCUMENT-END. */
     YAML_EMIT_DOCUMENT_END_STATE,
-
     /** Expect the first item of a flow sequence. */
     YAML_EMIT_FLOW_SEQUENCE_FIRST_ITEM_STATE,
     /** Expect an item of a flow sequence. */
@@ -1626,6 +1625,8 @@ typedef struct yaml_emitter_s {
     int canonical;
     /** The number of indentation spaces. */
     int best_indent;
+    /** Whether or not to indent block sequences in mapping context. */
+    int indent_mapping_sequence;
     /** The preferred width of the output lines. */
     int best_width;
     /** Allow unescaped non-ASCII characters? */
@@ -1873,6 +1874,16 @@ yaml_emitter_set_canonical(yaml_emitter_t *emitter, int canonical);
 
 YAML_DECLARE(void)
 yaml_emitter_set_indent(yaml_emitter_t *emitter, int indent);
+
+/*
+ * Set whether or not to indent block sequences in mapping context.
+ *
+ * @param[in,out]   emitter                   An emitter object.
+ * @param[in]       indent_mapping_sequence   Boolean.
+ */
+
+YAML_DECLARE(void)
+yaml_emitter_set_indent_mapping_sequence(yaml_emitter_t *emitter, int indent_mapping_sequence);
 
 /**
  * Set the preferred line width. @c -1 means unlimited.

--- a/src/api.c
+++ b/src/api.c
@@ -541,6 +541,18 @@ yaml_emitter_set_indent(yaml_emitter_t *emitter, int indent)
 }
 
 /*
+ * Set whether or not to indent block sequences in mapping context.
+ */
+
+YAML_DECLARE(void)
+yaml_emitter_set_indent_mapping_sequence(yaml_emitter_t *emitter, int indent_mapping_sequence)
+{
+    assert(emitter);    /* Non-NULL emitter object expected. */
+
+    emitter->indent_mapping_sequence = indent_mapping_sequence;
+}
+
+/*
  * Set the preferred line width.
  */
 

--- a/src/emitter.c
+++ b/src/emitter.c
@@ -886,7 +886,9 @@ yaml_emitter_emit_block_sequence_item(yaml_emitter_t *emitter,
     if (first)
     {
         if (!yaml_emitter_increase_indent(emitter, 0,
-                    (emitter->mapping_context && !emitter->indention)))
+                    (emitter->mapping_context
+                             && !emitter->indent_mapping_sequence
+                             && !emitter->indention)))
             return 0;
     }
 
@@ -1825,6 +1827,7 @@ yaml_emitter_write_indicator(yaml_emitter_t *emitter,
 
     emitter->whitespace = is_whitespace;
     emitter->indention = (emitter->indention && is_indention);
+/*    emitter->open_ended = 0; */
 
     return 1;
 }
@@ -1977,6 +1980,10 @@ yaml_emitter_write_plain_scalar(yaml_emitter_t *emitter,
 
     emitter->whitespace = 0;
     emitter->indention = 0;
+    if (emitter->root_context)
+    {
+        emitter->open_ended = 1;
+    }
 
     return 1;
 }


### PR DESCRIPTION
Problem: Downstream consumer of libyaml has some divergent formatting changes. Would prefer to use libyaml without modification. Possibly towards using system installed library: https://github.com/vubiostat/r-yaml/issues/102

It was felt important enough to downstream users to change this bit of formatting on output, so this is important to some users. 

Goal: Merge this change in with necessary tests, and understand why the formatting directive was necessary. 

Needs: (1) Blessing from dev team. (2) Test cases. 

This pull requests has the divergence between the two with one line commented out due to breaking two tests. If the line is commented in the following test snippet occurs with 2 broken tests:

```
...
ok 89 F6MC: More indented lines at the beginning of folded block scalars
not ok 90 F8F9: Spec Example 8.5. Chomping Trailing Lines
# --- data/F8F9/out.yaml	2022-02-14 09:59:24.889902598 -0600
# +++ /tmp/test.out	2022-02-14 09:59:26.145888379 -0600
# @@ -5,4 +5,3 @@
#  keep: |+
#    # text
#  
# -...
ok 91 FP8R: Zero indented block scalar
ok 92 FQ7F: Spec Example 2.1. Sequence of Scalars
ok 93 FTA2: Single block sequence with anchor and explicit document start
ok 94 FUP4: Flow Sequence in Flow Sequence
ok 95 G4RS: Spec Example 2.17. Quoted Scalars
ok 96 G5U8: Plain dashes in flow sequence
ok 97 G992: Spec Example 8.9. Folded Scalar
ok 98 GH63: Mixed Block Mapping (explicit to implicit)
ok 99 H2RW: Blank lines
ok 100 H3Z8: Literal unicode
ok 101 HMK4: Spec Example 2.16. Indentation determines scope
ok 102 HMQ5: Spec Example 6.23. Node Properties
ok 103 HS5T: Spec Example 7.12. Plain Lines
ok 104 HWV9: Document-end marker
ok 105 J5UC: Multiple Pair Block Mapping
ok 106 J7PZ: Spec Example 2.26. Ordered Mappings
ok 107 J7VC: Empty Lines Between Mapping Elements
ok 108 J9HZ: Spec Example 2.9. Single Document with Two Comments
ok 109 JHB9: Spec Example 2.7. Two Documents in a Stream
ok 110 JQ4R: Spec Example 8.14. Block Sequence
ok 111 JS2J: Spec Example 6.29. Node Anchors
ok 112 K3WX: Colon and adjacent value after comment on next line
ok 113 K4SU: Multiple Entry Block Sequence
ok 114 K527: Spec Example 6.6. Line Folding
not ok 115 K858: Spec Example 8.6. Empty Scalar Chomping
# --- data/K858/out.yaml	2022-02-14 09:59:24.894902541 -0600
# +++ /tmp/test.out	2022-02-14 09:59:26.436885084 -0600
# @@ -2,4 +2,3 @@
#  clip: ""
#  keep: |2+
#  
# -...
ok 116 KMK3: Block Submapping
ok 117 L94M: Tags in Explicit Map
...
```