### PR TITLE
Bug fix: Install yaml.h to INSTALL_INCLUDE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ target_include_directories(yaml PUBLIC
 install(
   FILES
     include/yaml.h
-  DESTINATION include COMPONENT Development
+  DESTINATION ${INSTALL_INCLUDE_DIR} COMPONENT Development
   )
 
 install(


### PR DESCRIPTION
The CMake build has a variable `INSTALL_INCLUDE_DIR` that controls the folder headers get installed to. It appears the intent is to allow installing the header to a different folder using `cmake -DINSTALL_INCLUDE_DIR=...` , and the include directory on the exported `yaml` target reflects that.

 Unfortunately, the actual `install()` command ignores it and hard codes `include`. This PR fixes that bug.