### PR TITLE
Avoid a crash when using `musl`

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -1,3 +1,5 @@
+#define _GNU_SOURCE
+#include <string.h>
 
 #include "yaml_private.h"
 


### PR DESCRIPTION
Without this PR, a warning is emitted when compiling libyaml with musl libc:

```
api.c: In function 'yaml_strdup':
api.c:66:27: warning: implicit declaration of function 'strdup'; did you mean 'strcmp'? [-Wimplicit-function-declaration]
     return (yaml_char_t *)strdup((char *)str);
                           ^~~~~~
                           strcmp
```

If the warning is ignored (default behaviour), a program using libyaml starts but crashes because `strdup()` is returning garbage:

```
(gdb) b parser.c:1365
Breakpoint 1 at 0x43ecf4: file parser.c, line 1365.
(gdb) run
(...)
Breakpoint 1, yaml_parser_append_tag_directive (
    parser=parser@entry=0x7ffffff5f0, value=...,
    allow_duplicates=allow_duplicates@entry=1, mark=...) at parser.c:1365
1365    in parser.c
(gdb) p copy
$1 = {
  handle = 0xffffffffb8000fe0 <error: Cannot access memory at address 0xffffffffb8000fe0>,
  prefix = 0xffffffffb7f76fe0 <error: Cannot access memory at address 0xffffffffb7f76fe0>}
```

The solution is to follow `strdup()`'s manpage and define `_GNU_SOURCE` before including `string.h`.

I guess when using other libc, it fallbacks to another version or maybe `_GNU_SOURCE` is set by default but it certainly uses a valid `strdup`.

Fixes: 625fcfe ("Refactor internal and external API.")