### PR TITLE
Replace the only two occurrences of \t in C code

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -121,7 +121,7 @@ yaml_stack_extend(void **start, void **top, void **end)
     void *new_start;
 
     if ((char *)*end - (char *)*start >= INT_MAX / 2)
-	return 0;
+        return 0;
 
     new_start = yaml_realloc(*start, ((char *)*end - (char *)*start)*2);
 

--- a/src/emitter.c
+++ b/src/emitter.c
@@ -16,7 +16,7 @@
 #define PUT(emitter,value)                                                      \
     (FLUSH(emitter)                                                             \
      && (*(emitter->buffer.pointer++) = (yaml_char_t)(value),                   \
-         emitter->column++,                                             	\
+         emitter->column++,                                                     \
          1))
 
 /*


### PR DESCRIPTION
The use of hard tabs, where everything else in this project uses 4-space indent, causes the code to be displayed in a misleading way when tab size is anything other than 8, including in GitHub's web UI.

https://github.com/yaml/libyaml/blob/f8f760f7387d2cc56a2fc7b1be313a3bf3f7f58c/src/api.c#L123-L126

![Screenshot from 2022-08-01 14-14-13](https://user-images.githubusercontent.com/1940490/182247799-94f992c8-341a-48f7-a94d-d0ec0efd4f72.png)
