### PR TITLE
Change sprintf to snprintf

### DIFF
--- a/src/dumper.c
+++ b/src/dumper.c
@@ -251,7 +251,7 @@ yaml_emitter_generate_anchor(SHIM(yaml_emitter_t *emitter), int anchor_id)
 
     if (!anchor) return NULL;
 
-    sprintf((char *)anchor, ANCHOR_TEMPLATE, anchor_id);
+    snprintf((char *)anchor, ANCHOR_TEMPLATE_LENGTH-1, ANCHOR_TEMPLATE, anchor_id);
 
     return anchor;
 }


### PR DESCRIPTION
On macOS, sprintf has been deprecated. Building dumper.c will error if `-Werror,-Wdeprecated-declaration` is set.

```
/Users/y/w/iree-ios/iree/third_party/libyaml/src/dumper.c:254:5: error: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations]
    sprintf((char *)anchor, ANCHOR_TEMPLATE, anchor_id);
    ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
```