### PR TITLE
Update Github actions

### DIFF
--- a/.github/workflows/dist.yaml
+++ b/.github/workflows/dist.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: env | sort
 
     - name: Get image

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
         - macOS-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - run: env | sort
     - name: Install software


### PR DESCRIPTION
There are deprecation warnings:
https://github.com/perlpunk/libyaml/actions/runs/8514766671
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```