### PR TITLE
Handle closing flow sequence after explicit key

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -1058,6 +1058,13 @@ yaml_parser_parse_flow_sequence_entry_mapping_key(yaml_parser_t *parser,
             return 0;
         return yaml_parser_parse_node(parser, event, 0, 0);
     }
+    else if (token->type == YAML_FLOW_SEQUENCE_END_TOKEN) {
+        parser->state = POP(parser, parser->states);
+        (void)POP(parser, parser->marks);
+        SEQUENCE_END_EVENT_INIT(*event, token->start_mark, token->end_mark);
+        SKIP_TOKEN(parser);
+        return 1;
+    }
     else {
         yaml_mark_t mark = token->end_mark;
         SKIP_TOKEN(parser);


### PR DESCRIPTION
Currently after an explicit flow key '?' in a flow sequence, an immediately following closing ] is ignored by the parser:

    % echo '[ ? ]' | ./tests/run-parser-test-suite --flow keep
    +STR
    +DOC
    +SEQ []
    +MAP {}
    =VAL :
    =VAL :
    -MAP
    Parse error: did not find expected ',' or ']'
    Line: 2 Column: 1
    % echo '[ ? ] ]' | ./tests/run-parser-test-suite --flow keep
    +STR
    +DOC
    +SEQ []
    +MAP {}
    =VAL :
    =VAL :
    -MAP
    -SEQ
    -DOC
    -STR

It is read correctly by the scanner as a YAML_FLOW_SEQUENCE_END_TOKEN, and the flow_level is decreased. Then it is passed to the parser where it gets ignored.
This leads to invalid YAML being accepted, and valid YAML resulting in an error.

Also the flow_level is incorrectly decreased, so you can nest sequences like that without running in to the MAX_NESTING_LEVEL.