### PR TITLE
Fix closing flow sequence after explicit key

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -1059,11 +1059,9 @@ yaml_parser_parse_flow_sequence_entry_mapping_key(yaml_parser_t *parser,
         return yaml_parser_parse_node(parser, event, 0, 0);
     }
     else if (token->type == YAML_FLOW_SEQUENCE_END_TOKEN) {
-        parser->state = POP(parser, parser->states);
-        (void)POP(parser, parser->marks);
-        SEQUENCE_END_EVENT_INIT(*event, token->start_mark, token->end_mark);
-        SKIP_TOKEN(parser);
-        return 1;
+        yaml_mark_t mark = token->start_mark;
+        parser->state = YAML_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_VALUE_STATE;
+        return yaml_parser_process_empty_scalar(parser, event, mark);
     }
     else {
         yaml_mark_t mark = token->end_mark;


### PR DESCRIPTION
The fix in #295 was not correct.

    # cat a.yaml
    ---
    [?]

    # Before
    % ./tests/run-parser-test-suite --flow keep < a.yaml
    +STR
    +DOC ---
    +SEQ []
    +MAP {}
    -SEQ
    -DOC
    -STR

    % ./tests/run-loader a.yaml
    [1] Loading 'a.yaml': run-loader: loader.c:470: yaml_parser_load_sequence_end: Assertion `parser->document->nodes.start[index-1].type == YAML_SEQUENCE_NODE' failed.
    [1]    21446 IOT instruction (core dumped)  ./tests/run-loader a.yaml

    # After
    % ./tests/run-parser-test-suite --flow keep < a.yaml
    +STR
    +DOC ---
    +SEQ []
    +MAP {}
    =VAL :
    =VAL :
    -MAP
    -SEQ
    -DOC
    -STR

    % ./tests/run-loader a.yaml
    [1] Loading 'a.yaml': SUCCESS (1 documents)