### PR TITLE
Replace Deprecated Function Name

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -63,7 +63,7 @@ yaml_strdup(const yaml_char_t *str)
     if (!str)
         return NULL;
 
-    return (yaml_char_t *)strdup((char *)str);
+    return (yaml_char_t *)_strdup((char *)str);
 }
 
 /*


### PR DESCRIPTION
##[warning]src\YamlCppLib\libyaml\src\api.c(66,27): Warning C4996: 'strdup': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _strdup.