### PR TITLE
Update minimum required CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.20)
 project (yaml C)
 
 set (YAML_VERSION_MAJOR 0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.5)
 project (yaml C)
 
 set (YAML_VERSION_MAJOR 0)


### PR DESCRIPTION
CMake v4.0 just came out, and is not compatible with CMake versions less than 3.5. So, if you try to build libyaml with CMake v4.0, cmake throws an error because in the main branch, the CMakeLists.txt file has the line `cmake_minimum_required(VERSION 3.0)`. This pull requests changes the minimum required version of CMake from v3.0 to v3.20 so that libyaml builds with the latest versions of CMake.