### PR TITLE
tests/test-reader: Fix memory leak

### DIFF
--- a/tests/test-reader.c
+++ b/tests/test-reader.c
@@ -152,9 +152,9 @@ int check_utf8_sequences(void)
                             parser.problem, (long)parser.problem_offset);
                 }
             }
+            yaml_parser_delete(&parser);
             if (*end == '!') break;
             start = ++end;
-            yaml_parser_delete(&parser);
         };
         printf("\n");
     }


### PR DESCRIPTION
```
Breaking the loop before `yaml_parser_delete()` means that in some cases the parser will not be deinitialized properly, leading to memory leaks, trigger sanitizers. Fix that by moving the call before the break.

  Direct leak of 2064384 byte(s) in 42 object(s) allocated from:
    0. 0x7fabc5d20e15 in malloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:67
    1. 0x5595a1c718ca in yaml_malloc (/libyaml/build/test-reader+0x398ca) (BuildId: e39075df3c1f5c997cb01bed616cc6960d0d00ac)
    2. 0x5595a1c735a5 in yaml_parser_initialize (/libyaml/build/test-reader+0x3b5a5) (BuildId: e39075df3c1f5c997cb01bed616cc6960d0d00ac)
    3. 0x5595a1c6e984 in check_utf8_sequences (/libyaml/build/test-reader+0x36984) (BuildId: e39075df3c1f5c997cb01bed616cc6960d0d00ac)
    4. 0x5595a1c71688 in main (/libyaml/build/test-reader+0x39688) (BuildId: e39075df3c1f5c997cb01bed616cc6960d0d00ac)
    5. 0x7fabc52376b4  (/usr/lib/libc.so.6+0x276b4) (BuildId: 468e3585c794491a48ea75fceb9e4d6b1464fc35)
    6. 0x7fabc5237768 in __libc_start_main (/usr/lib/libc.so.6+0x27768) (BuildId: 468e3585c794491a48ea75fceb9e4d6b1464fc35)
    7. 0x5595a1c6e314 in _start (/libyaml/build/test-reader+0x36314) (BuildId: e39075df3c1f5c997cb01bed616cc6960d0d00ac)
```