### PR TITLE
Fix C4703: initialize 'input' pointer to NULL

### DIFF
--- a/tests/run-emitter-test-suite.c
+++ b/tests/run-emitter-test-suite.c
@@ -13,7 +13,7 @@ int usage(int ret);
 
 int main(int argc, char *argv[])
 {
-    FILE *input;
+    FILE *input = NULL;
     yaml_emitter_t emitter;
     yaml_event_t event;
     yaml_version_directive_t *version_directive = NULL;

--- a/tests/run-parser-test-suite.c
+++ b/tests/run-parser-test-suite.c
@@ -8,7 +8,7 @@ int usage(int ret);
 
 int main(int argc, char *argv[])
 {
-    FILE *input;
+    FILE *input = NULL;
     yaml_parser_t parser;
     yaml_event_t event;
     int flow = -1; /** default no flow style collections */


### PR DESCRIPTION
Initialize `FILE *input` to `NULL` in `run-parser-test-suite.c` and `run-emitter-test-suite.c` to fix MSVC warning C4703 (potentially uninitialized local pointer variable used). This is required when compiling with `/sdl`. 

Fixes yaml/libyaml#325