### PR TITLE
Bump cmake_minimum_required to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project (yaml C)
 
 set (YAML_VERSION_MAJOR 0)


### PR DESCRIPTION
CMake 4.x on macOS CI runners dropped support for
cmake_minimum_required below 3.5, breaking builds.