### PR TITLE
ci: Update github actions versions

### DIFF
--- a/.github/workflows/dist.yaml
+++ b/.github/workflows/dist.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - run: env | sort
 
     - name: Get image
@@ -21,7 +21,7 @@ jobs:
         make -C pkg/docker libyaml-dist-ci
         ls -l pkg/docker/output
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v7
       with:
         name: release
         path: pkg/docker/output/yaml-0*


### PR DESCRIPTION
https://github.com/yaml/libyaml/actions/runs/24842904090
> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

I updated checkout along the way.