### PR TITLE
Add getter and feature macro for nest depth control

### DIFF
--- a/include/yaml.h
+++ b/include/yaml.h
@@ -1456,10 +1456,26 @@ yaml_parser_parse(yaml_parser_t *parser, yaml_event_t *event);
 YAML_DECLARE(int)
 yaml_parser_load(yaml_parser_t *parser, yaml_document_t *document);
 
+#define LIBYAML_FEATURE_NEST_DEPTH_CONTROL
+
 /**
- * Set the maximum depth of nesting.
+ * Get the maximum depth of nesting.
  *
  * Default: 1000
+ *
+ * Each nesting level increases the stack and the number of previous
+ * starting events that the parser has to check.
+ *
+ * @returns The maximum number of allowed nested events.
+ */
+
+YAML_DECLARE(int)
+yaml_get_max_nest_level();
+
+/** @} */
+
+/**
+ * Set the maximum depth of nesting.
  *
  * Each nesting level increases the stack and the number of previous
  * starting events that the parser has to check.

--- a/src/parser.c
+++ b/src/parser.c
@@ -164,6 +164,17 @@ static int
 yaml_parser_append_tag_directive(yaml_parser_t *parser,
         yaml_tag_directive_t value, int allow_duplicates, yaml_mark_t mark);
 
+/*
+ * Recursion limit controls.
+ */
+
+YAML_DECLARE(int)
+yaml_get_max_nest_level()
+{
+    return MAX_NESTING_LEVEL;
+}
+
+
 YAML_DECLARE(void)
 yaml_set_max_nest_level(int max)
 {


### PR DESCRIPTION
* Eases conditional compilation for wrappers (ala PyYAML and YAML::XS).
* Nest depth value getter eliminates need for wrappers to force-set a known default to expose as a property.
