### PR TITLE
ci: set least-privilege GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/dist.yaml
+++ b/.github/workflows/dist.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ release/* ]
 
+permissions:
+  contents: read
+
 jobs:
   dist:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
## What

Adds a workflow-level `permissions: { contents: read }` block to the affected workflow(s).

## Why

Without an explicit `permissions:` block, these workflows run with the broad default `GITHUB_TOKEN` scopes. The affected workflows only build, test, and/or fuzz the project — no job writes to the repository, releases, packages, or any other GitHub resource. Restricting the token to `contents: read` follows the principle of least privilege and limits the blast radius if any build/test/fuzz step (or a dependency it pulls in) were compromised. This matches GitHub-recommended and OpenSSF Scorecard "Token-Permissions" hardening guidance.

## Scope

- Additive only: one top-level `permissions` block per affected workflow.
- No change to triggers, jobs, steps, or action versions.
- YAML validated; `git diff --check` clean.

---
*Disclosure: I used AI assistance while preparing this change. The diff is small and I have reviewed it for correctness.*