### PR TITLE
Guard against NULL token in first-entry of collection parse functions

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -737,6 +737,7 @@ yaml_parser_parse_block_sequence_entry(yaml_parser_t *parser,
 
     if (first) {
         token = PEEK_TOKEN(parser);
+        if (!token) return 0;
         if (!PUSH(parser, parser->marks, token->start_mark))
             return 0;
         SKIP_TOKEN(parser);
@@ -845,6 +846,7 @@ yaml_parser_parse_block_mapping_key(yaml_parser_t *parser,
 
     if (first) {
         token = PEEK_TOKEN(parser);
+        if (!token) return 0;
         if (!PUSH(parser, parser->marks, token->start_mark))
             return 0;
         SKIP_TOKEN(parser);
@@ -960,6 +962,7 @@ yaml_parser_parse_flow_sequence_entry(yaml_parser_t *parser,
 
     if (first) {
         token = PEEK_TOKEN(parser);
+        if (!token) return 0;
         if (!PUSH(parser, parser->marks, token->start_mark))
             return 0;
         SKIP_TOKEN(parser);
@@ -1116,6 +1119,7 @@ yaml_parser_parse_flow_mapping_key(yaml_parser_t *parser,
 
     if (first) {
         token = PEEK_TOKEN(parser);
+        if (!token) return 0;
         if (!PUSH(parser, parser->marks, token->start_mark))
             return 0;
         SKIP_TOKEN(parser);


### PR DESCRIPTION
The four collection-entry parse functions call PEEK_TOKEN in their `if (first)` block and dereference the result via `token->start_mark` without checking for NULL. PEEK_TOKEN returns NULL when yaml_parser_fetch_more_tokens fails, so a read or allocation error there causes a NULL dereference before the mark is pushed.

Every other PEEK_TOKEN site in parser.c already guards with `if (!token) return 0;` (including the very next statement in each of these functions). This adds the same guard to the first-entry path in yaml_parser_parse_block_sequence_entry, yaml_parser_parse_block_mapping_key, yaml_parser_parse_flow_sequence_entry and yaml_parser_parse_flow_mapping_key.

Closes #337. The existing test suite still passes; a direct reproducer would need to inject a read failure mid-stream inside the scanner, which the current tests do not exercise.