### PR TITLE
Fix integer overflow in yaml_string_extend

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -74,6 +74,9 @@ YAML_DECLARE(int)
 yaml_string_extend(yaml_char_t **start,
         yaml_char_t **pointer, yaml_char_t **end)
 {
+    if (*end - *start >= INT_MAX / 2)
+        return 0;
+
     yaml_char_t *new_start = (yaml_char_t *)yaml_realloc((void*)*start, (*end - *start)*2);
 
     if (!new_start) return 0;


### PR DESCRIPTION
Adds a missing overflow check in `yaml_string_extend` mirroring the protection present in `yaml_stack_extend`.

Without this check, doubling the string size via `(*end - *start)*2` could wrap around if the buffer is already large, resulting in a smaller-than-expected allocation and a subsequent heap buffer overflow during `memset` or string operations.

`yaml_stack_extend` already has this guard:
```c
if ((char *)*end - (char *)*start >= INT_MAX / 2)
    return 0;
```

This PR applies the same protection to `yaml_string_extend`.