### PR TITLE
Do not count a leading BOM as a column (#334)

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1945,8 +1945,12 @@ yaml_parser_scan_to_next_token(yaml_parser_t *parser)
 
         if (!CACHE(parser, 1)) return 0;
 
-        if (parser->mark.column == 0 && IS_BOM(parser->buffer))
+        if (parser->mark.column == 0 && IS_BOM(parser->buffer)) {
             SKIP(parser);
+            /* A BOM is not content, so it must not advance the column: SKIP()
+               increments mark.column, so reset it here (#334). */
+            parser->mark.column = 0;
+        }
 
         /*
          * Eat whitespaces.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ foreach(name IN ITEMS
   run-parser
   run-parser-test-suite
   run-scanner
+  test-bom
   test-nesting
   test-reader
   test-version
@@ -26,4 +27,5 @@ endforeach()
 add_test(NAME version COMMAND test-version)
 add_test(NAME reader COMMAND test-reader)
 add_test(NAME nesting COMMAND test-nesting)
+add_test(NAME bom COMMAND test-bom)
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,8 +1,8 @@
 AM_CPPFLAGS = -I$(top_srcdir)/include -Wall
 #AM_CFLAGS = -Wno-pointer-sign
 LDADD = $(top_builddir)/src/libyaml.la
-TESTS = test-version test-reader test-nesting
-check_PROGRAMS = test-version test-reader test-nesting
+TESTS = test-version test-reader test-nesting test-bom
+check_PROGRAMS = test-version test-reader test-nesting test-bom
 noinst_PROGRAMS = run-scanner run-parser run-loader run-emitter run-dumper	\
 				  example-reformatter example-reformatter-alt	\
 				  example-deconstructor example-deconstructor-alt \

--- a/tests/test-bom.c
+++ b/tests/test-bom.c
@@ -1,0 +1,67 @@
+#include <yaml.h>
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <assert.h>
+
+/*
+ * Regression test for a leading BOM being counted as a column when the input
+ * encoding is set explicitly (https://github.com/yaml/libyaml/issues/334).
+ *
+ * With an explicit encoding the reader does not strip the BOM, so the scanner
+ * skips it instead. That skip must not advance the column: otherwise the first
+ * token starts at column 1 and a root-level block mapping fails to parse with
+ * "did not find expected <document start>".
+ */
+
+static int
+parse_scalars(const char *input, size_t length, yaml_encoding_t encoding)
+{
+    yaml_parser_t parser;
+    yaml_event_t event;
+    int scalars = 0;
+    int done = 0;
+
+    assert(yaml_parser_initialize(&parser));
+    yaml_parser_set_encoding(&parser, encoding);
+    yaml_parser_set_input_string(&parser, (const unsigned char *)input, length);
+
+    while (!done) {
+        if (!yaml_parser_parse(&parser, &event)) {
+            scalars = -1;
+            break;
+        }
+        if (event.type == YAML_SCALAR_EVENT)
+            scalars++;
+        done = (event.type == YAML_STREAM_END_EVENT);
+        yaml_event_delete(&event);
+    }
+
+    yaml_parser_delete(&parser);
+    return scalars;
+}
+
+int
+main(void)
+{
+    /* UTF-8 BOM followed by a root-level block mapping with two entries. */
+    const char input[] = "\xEF\xBB\xBF" "a: b\nc: d\n";
+    size_t length = sizeof(input) - 1;
+
+    printf("BOM + explicit UTF-8 encoding ... ");
+    fflush(stdout);
+    assert(parse_scalars(input, length, YAML_UTF8_ENCODING) == 4);
+    printf("OK\n");
+
+    printf("BOM + detected encoding ... ");
+    fflush(stdout);
+    assert(parse_scalars(input, length, YAML_ANY_ENCODING) == 4);
+    printf("OK\n");
+
+    return 0;
+}


### PR DESCRIPTION
Fixes #334.

### Problem

When the input encoding is set explicitly with `yaml_parser_set_encoding()` (e.g. `YAML_UTF8_ENCODING`), the reader's `determine_encoding()` BOM stripping is skipped, so a leading BOM reaches the scanner. `yaml_parser_scan_to_next_token()` skips it with `SKIP(parser)` — but `SKIP` increments `parser->mark.column`, so the first real token starts at column 1 instead of 0. A root-level block mapping then terminates at the first newline and parsing fails with `did not find expected <document start>`. Per YAML 1.2 section 5.2 a BOM is not content and must not advance the column. The same input parses correctly under `YAML_ANY_ENCODING` (where the BOM was already stripped upstream).

### Fix

Reset `mark.column` to 0 after skipping the BOM, so the following token starts at column 0.

### Test

Added `tests/test-bom.c` (registered in `Makefile.am` and `CMakeLists.txt`, following `test-nesting`): it parses `"\xEF\xBB\xBF" "a: b\nc: d\n"` under both `YAML_UTF8_ENCODING` and `YAML_ANY_ENCODING` and asserts both fully parse the two-entry mapping. Red-green verified: before the fix the explicit-UTF-8 case fails (`did not find expected <document start>`), after the fix both pass. The existing `test-reader`/`test-nesting`/`test-version` still pass, and parser-token output is byte-identical to the unmodified build across `examples/*.yaml` (the fix only affects the BOM-at-column-0 path).
