### PR TITLE
Fix scanner counting the leading BOM as a column when encoding is explicit

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1945,8 +1945,18 @@ yaml_parser_scan_to_next_token(yaml_parser_t *parser)
 
         if (!CACHE(parser, 1)) return 0;
 
-        if (parser->mark.column == 0 && IS_BOM(parser->buffer))
-            SKIP(parser);
+        /*
+         * The BOM is not a character in the document (YAML 1.2 spec,
+         * section 5.2), so it must not advance mark.column the way a
+         * regular SKIP() would - otherwise the rest of the first line
+         * is off by one column.
+         */
+
+        if (parser->mark.column == 0 && IS_BOM(parser->buffer)) {
+            parser->mark.index ++;
+            parser->unread --;
+            parser->buffer.pointer += WIDTH(parser->buffer);
+        }
 
         /*
          * Eat whitespaces.


### PR DESCRIPTION
Closes #334.

When the encoding is set explicitly with `yaml_parser_set_encoding()`, `yaml_parser_determine_encoding()` is skipped entirely, so the BOM auto-detection path (which strips a leading BOM without touching `mark.column`) never runs. The BOM then reaches the scanner, where `yaml_parser_scan_to_next_token()` calls `SKIP()` on it. `SKIP()` bumps `mark.column` along with the buffer position, so the rest of the first line ends up starting one column further right than it should.

That off-by-one is enough to break block mapping detection on the first line: a root-level `key: value` pair parses fine, but the mapping is considered closed as soon as the line wraps, and parsing then fails with "did not find expected <document start>".

Per YAML 1.2 section 5.2 the BOM isn't part of the document content, so this skip shouldn't move `mark.column` at all - which is exactly what the auto-detection path already does for a BOM it strips. This fix does the same thing at the scanner level.

Verified with a small standalone reproduction: parsing `"\xEF\xBB\xBFa: b\nc: d\n"` with the encoding explicitly set to `YAML_UTF8_ENCODING`. On unmodified master this fails after the first pair with "did not find expected <document start>"; with the fix applied all four scalars parse correctly. Confirmed the failure disappears specifically because of this change by reverting it locally and re-running (stash test). Ran the existing CMake test suite (version/reader/nesting) plus the parser test suite against a handful of BOM and non-BOM documents under ASan/UBSan, no failures or sanitizer reports.

Originally reported via Ruby's Psych, which always sets the encoding explicitly and so hit this on every BOM-prefixed YAML document.